### PR TITLE
Changed install docs to go to releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,42 @@ We are looking for early adopters and contributors. The software is functional, 
 - Python 3 - installed
 - Docker - installed and running
 
-## Installation (Quick Start)
+## Install and Run (Quick Start)
+
+_For those that just want to run, use and/or explore the application._
+
+Download the latest release from: https://github.com/cassandra/home-information/releases/latest.
+
+Un'zip or un'tar that in your chosen location.
+
+
+
+``` shell
+git clone git@github.com:cassandra/home-information.git
+cd home-information*
+make env-build
+make docker-build
+make docker-run-fg
+```
+See the [Installation Page](docs/Installation.md) for more details and troubleshooting.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ``` shell
 git clone git@github.com:cassandra/home-information.git
 cd home-information
@@ -42,6 +77,8 @@ make docker-run
 Then visit: [http://localhost:9411](http://localhost:9411) and the [Getting Started Page](docs/GettingStarted.md).
 
 # Development
+
+_For those that are interested in contributing or just peeking under the hood._
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -23,43 +23,13 @@ We are looking for early adopters and contributors. The software is functional, 
 
 _For those that just want to run, use and/or explore the application._
 
-Download the latest release from: https://github.com/cassandra/home-information/releases/latest.
-
-Un'zip or un'tar that in your chosen location.
-
-
-
+Download the latest release from: https://github.com/cassandra/home-information/releases/latest and Un'zip or un'tar it.
 ``` shell
-git clone git@github.com:cassandra/home-information.git
+unzip ~/Downloads/home-information-*.zip 
 cd home-information*
 make env-build
 make docker-build
 make docker-run-fg
-```
-See the [Installation Page](docs/Installation.md) for more details and troubleshooting.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-``` shell
-git clone git@github.com:cassandra/home-information.git
-cd home-information
-make env-build
-make docker-build
 ```
 See the [Installation Page](docs/Installation.md) for more details and troubleshooting.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,7 @@ See the [Dependencies Page](dev/Dependencies.md) if you want help installing tho
 
 ## Pre-install Considerations
 
-By default, the installation does not require sign in and does not have email configure for alerts.  This is to make it as simple as possible to get started.  However, before installing, you might want to consider whether you want to enable these.  You can change these after the initial install by adjusting the environment variable file.
+By default, the installation process will not configure the app for user sign ins and does not have email configured for alerts.  This is to make it as simple as possible to get started.  However, before installing, you might want to consider whether you want to enable these.  You can change these after the initial install by adjusting the environment variable file that gets generated.
 
 ### Emails
 
@@ -31,16 +31,26 @@ PROJ_DIR="proj"
 mkdir -p $PROJ_DIR
 cd $PROJ_DIR
 ```
-Download the code:
+
+#### Downloading
+
+Download the code from: https://github.com/cassandra/home-information/releases/latest.
+
+Un'zip (or un'tar) the release code in your chosen project root location. e.g., 
+
 ``` shell
-git clone git@github.com:cassandra/home-information.git
-cd home-information
+cd $PROJ_DIR
+unzip ~/Downloads/home-information-*.zip 
+
+# Or if using tar'ball:
+tar zxvf ~/Downloads/home-information-*.tar.gz
 ```
 
 #### Building
 
 Generate the environment variable file and review with the command below. The file will contain sensitive secrets and are stored in a `.private` directory. Also note that administrative credentials created during this next step and save them somewhere safe.
 ``` shell
+cd $PROJ_DIR/home-information*
 make env-build
 ```
 This generates an environment variable file used when running:

--- a/docs/dev/Setup.md
+++ b/docs/dev/Setup.md
@@ -6,7 +6,7 @@
 
 - Sign into your GitHub account (required).
 - Go to the main repository on GitHub: https://github.com/cassandra/home-information
-- Click the "Fork" button in the upper-right corner.
+- Click the "Fork" button in the upper-right corner. (You will be forking from the `staging` branch.)
 - This creates a copy of the repository in the your GitHub account (keep same name if you can for simplicity).
 - The forked repo will be located at https://github.com/${YOURUSERNAME}/home-information.git (if you kept the same repo name).
 
@@ -37,15 +37,7 @@ git config --global user.email "${YOUR_EMAIL}"
 git remote add upstream https://github.com/cassandra/home-information.git
 ```
 
-Your "origin" should already be pointing to your forked repository, but to be sure you can use one of these:
-``` shell
-git remote add origin git@github.com:${YOURUSERNAME}/home-information.git
-
-# If no ssh keys added to GitHub
-git remote set-url origin https://github.com/${YOURUSERNAME}/home-information.git
-```
-
-Verify everything is set up properly:
+Your "origin" should already be pointing to your forked repository, but check this and the "upstream" settings:
 ``` shell
 git remote -v
 
@@ -56,13 +48,13 @@ upstream  https://github.com/cassandra/home-information.git (fetch)
 upstream  https://github.com/cassandra/home-information.git (push)
 ```
 
-## Staging Branch Setup
 
-You will have forked the `master` branch, but all your branches and pull request contributions will be targeting the `staging` branch.  To get your fork and local repositories in sync with the `staging` branch:
+If your origin is not set properly, re-verify after setting with:
 ``` shell
-git fetch upstream
-git checkout -b staging upstream/staging
-git push origin staging
+git remote add origin git@github.com:${YOURUSERNAME}/home-information.git
+
+# If no SSH keys were added to GitHub, you'll need this instead:
+git remote set-url origin https://github.com/${YOURUSERNAME}/home-information.git
 ```
 
 ## Environment Setup


### PR DESCRIPTION
## Pull Request: Change Install Docs to Use Releases
We want to have the default branch for this repository set to the `staging` branch since that is where all clones, forks and PRs should be targeted.  However, the install process for non-developers was having them start with `git clone` and for that, we did not want them to get the `staging` branch but the `master` branch.

The obvious (now) solution is to have non-developers pull the code from a GitHub release zip/tar file.  We updated the installation and development setup docs to reflect this change.


## Category
<!-- Choose the type of change. -->
- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ X ] **Docs** (Documentation updates)
- [ ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)
