### PR TITLE
Fixed Makefile and Dockerfile to ensure execute permissions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 ## Bug Description
-<!-- A clear and concise description of what the bug is. -->
 
 ## Steps to Reproduce
 1. Go to '...'
@@ -16,10 +15,8 @@ assignees: ''
 3. See error '...'
 
 ## Expected Behavior
-<!-- Describe what you expected to happen instead. -->
 
 ## Screenshots (if applicable)
-<!-- Add screenshots to help visualize the problem. -->
 
 ## Environment
 - **OS:** [e.g., Windows 11, macOS 14, Ubuntu 22.04]
@@ -27,7 +24,6 @@ assignees: ''
 - **Other relevant details:**
 
 ## Additional Context
-<!-- Add any other context, logs, or error messages that might help diagnose the issue. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -9,16 +9,12 @@ assignees: ''
 ## Documentation Issue
 
 ### What needs to be updated?
-<!-- Describe the documentation that is missing, incorrect, or unclear. -->
 
 ### Link to Affected Page(s)
-<!-- Provide a link to the specific documentation page if applicable. -->
 
 ### Suggested Improvement
-<!-- How should this documentation be improved? -->
 
 ### Additional Context
-<!-- Add any other context or screenshots related to this issue. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,16 +9,12 @@ assignees: ''
 ## Feature Request
 
 ### Is your feature request related to a problem? Please describe.
-<!-- A clear and concise description of what the problem is. Ex: "I'm frustrated when..." -->
 
 ### Describe the solution you'd like
-<!-- A clear and concise description of what you want to happen. -->
 
 ### Alternatives you've considered
-<!-- Any alternative solutions or features you've thought about? -->
 
 ### Additional context
-<!-- Add any other context, screenshots, or examples about the feature request here. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/operations.md
+++ b/.github/ISSUE_TEMPLATE/operations.md
@@ -9,22 +9,17 @@ assignees: ''
 ## Ops / Deployment Issue
 
 ### What is the issue?
-<!-- Describe the operational issue you are facing (e.g., deployment failure, build issue). -->
 
 ### Steps to Reproduce
-<!-- Provide a step-by-step guide to reproduce the problem if applicable. -->
 1. Step 1
 2. Step 2
 3. Step 3
 
 ### Related System/Component
-<!-- Specify the system, service, or deployment component affected (e.g., Docker, GitHub Actions, Kubernetes). -->
 
 ### Logs / Screenshots (if applicable)
-<!-- Paste any relevant logs or screenshots here. -->
 
 ### Suggested Fix (if applicable)
-<!-- If you have any ideas on how this could be fixed, describe them here. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -9,23 +9,18 @@ assignees: ''
 ## Refactor Request
 
 ### What part of the code needs refactoring?
-<!-- Specify the module, function, or file that needs refactoring. -->
 
 ### Why should this be refactored?
-<!-- Clearly explain the reason for refactoring. For example:
 - Code is difficult to understand or maintain.
 - Code violates best practices.
 - There is significant duplication or inefficiency.
 -->
 
 ### Expected Outcome
-<!-- Describe the expected benefits of the refactor (e.g., better readability, performance improvements). -->
 
 ### Related Code or Files
-<!-- Provide links to the relevant code or mention specific files. -->
 
 ### Additional Context
-<!-- Add any other relevant information, examples, or links to discussions. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/tests.md
+++ b/.github/ISSUE_TEMPLATE/tests.md
@@ -9,25 +9,19 @@ assignees: ''
 ## Test Issue
 
 ### What test-related issue are you reporting?
-<!-- Describe whether it's a missing test, a flaky test, or a needed improvement. -->
 
 ### Affected Module or Component
-<!-- Specify the part of the project where the test is missing or failing (e.g., authentication, API, frontend). -->
 
 ### Suggested Test Improvement
-<!-- If applicable, describe how the test should be improved or fixed. -->
 
 ### Steps to Reproduce (if applicable)
-<!-- If the issue relates to a failing or flaky test, provide steps to reproduce. -->
 1. Step 1
 2. Step 2
 3. Step 3
 
 ### Related Test Files
-<!-- Link to or mention the test files that need changes. -->
 
 ### Additional Context
-<!-- Any other relevant information, logs, or error messages. -->
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY package/docker_entrypoint.sh /src/entrypoint.sh
 RUN chmod +x /src/entrypoint.sh
 
 COPY src /src
+RUN chmod +x /src/bin/docker-start-gunicorn.sh
 
 ENTRYPOINT ["/src/entrypoint.sh"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,42 @@
-export HI_VERSION = $(shell cat HI_VERSION)
-
 NOW_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+SCRIPTS = deploy/env-generate.py deploy/run_container.sh
 
 .SECONDARY:
 
+.DEFAULT_GOAL := fix-permissions
+
 docker-build:	Dockerfile
+	@HI_VERSION=$$(cat HI_VERSION); \
 	docker build \
 		--label "name=hi" \
-		--label "version=$(HI_VERSION)" \
+		--label "version=$$HI_VERSION" \
 		--label "build-date=$(NOW_DATE)" \
-		--tag hi:$(HI_VERSION) \
+		--tag hi:$$HI_VERSION \
 		--tag hi:latest .
 
-docker-run:	.private/env/local.dev Dockerfile
+docker-run:	.private/env/local.dev Dockerfile fix-permissions
 	./deploy/run_container.sh -bg
 
-docker-run-fg:	.private/env/local.dev Dockerfile
+docker-run-fg:	.private/env/local.dev Dockerfile fix-permissions
 	./deploy/run_container.sh
 
 docker-stop:	
 	docker stop hi
 
-env-build:	.private/env/local.dev
+env-build:	.private/env/local.dev fix-permissions
 	./deploy/env-generate.py --env-name local
 
-env-build-dev:	.private/env/development.dev
+env-build-dev:	.private/env/development.sh fix-permissions
 	./deploy/env-generate.py --env-name development
 
 .private/env/local.dev:
 
+.private/env/development.sh:
 
-.private/env/development.dev:
+.PHONY:	fix-permissions
+
+fix-permissions:
+	@echo "Setting execute permissions for $(SCRIPTS)"
+	chmod +x $(SCRIPTS)
+


### PR DESCRIPTION
## Pull Request: [Short Title]
Adding explicit execute permission to scripts to compensate for GitHub release .ZIP files not preserving permission.

### Issue Link
Closes 17

---

## Category
- [ ] **Feature** (New functionality)
- [ X ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ X ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
- Change helper scripts' perms in Makefile
- Changed gnuicorn start perms in Dockerfile
- Some additional Makefile improvement tweaks
- Removed verbosity from GitHub issue templates

