### PR TITLE
Improved and fixed setting startup race condition.

### DIFF
--- a/src/hi/apps/common/initializer.py
+++ b/src/hi/apps/common/initializer.py
@@ -1,0 +1,80 @@
+import asyncio
+import threading
+from typing import Callable, Coroutine, Any
+
+
+class CoordinatedInitializer:
+    """
+    Used for one-time initializations that are shared across threads and
+    asyncio tasks to prevent race conditions and ensure a function runs only once.
+    """
+    
+    def __init__( self, initialization_function: Callable[[], Coroutine[Any, Any, Any]] ):
+        self._initialization_function = initialization_function  # async function
+        self._lock = threading.Lock()  # Protects initialization across threads
+        self._initialization_complete = asyncio.Event()  # Signals when initialization is done
+        self._was_initialized = False  # Protects against race condition on the async event itself
+        return
+    
+    def initialize_sync( self ):
+        with self._lock:
+            if self._was_initialized:
+                return
+            asyncio.run( self._run_async())
+        return
+    
+    async def initialize_async( self ):
+        if self._was_initialized:
+            await self._initialization_complete.wait()
+            return
+
+        async with asyncio.Lock():  # Inner lock to prevent concurrent async initialization
+            if self._was_initialized:  # Check again inside the async lock
+                await self._initialization_complete.wait()
+                return
+
+            await self._initialization_function()
+            self._was_initialized = True
+            self._initialization_complete.set()
+        return
+    
+    async def _run_async( self, initialization_function ):
+        await self._initialization_function()
+        return
+    
+
+# Example usage:
+
+async def initialize_subsystems():  # Your actual initialization logic
+    # ... your _discover_app_settings and _load_or_create_settings logic here ...
+    await asyncio.sleep(1) # Example operation
+    return ["subsystem1", "subsystem2"]
+
+
+async def initialize_database_connections(): # Another example initialization
+    await asyncio.sleep(1)
+    # ... database connection logic ...
+    return "database_connection_pool"
+
+# Create instances of the CoordinatedInitializer:
+subsystem_initializer = CoordinatedInitializer()
+database_initializer = CoordinatedInitializer()
+
+
+# In your Django view (synchronous):
+def my_view(request):
+    subsystems = subsystem_initializer.initialize_sync(initialize_subsystems)
+    database = database_initializer.initialize_sync(initialize_database_connections)
+    # ... rest of your view logic, using subsystems and database
+
+# In your background thread:
+def background_thread_function():
+    async def run_tasks():
+        subsystems = await subsystem_initializer.initialize_async(initialize_subsystems)
+        database = await database_initializer.initialize_async(initialize_database_connections)
+        # ... use subsystems and database in background tasks ...
+
+    asyncio.run(run_tasks())
+
+background_thread = threading.Thread(target=background_thread_function)
+background_thread.start()

--- a/src/hi/apps/config/apps.py
+++ b/src/hi/apps/config/apps.py
@@ -1,6 +1,16 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 
 
 class ConfigConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "hi.apps.config"
+    
+    def ready(self):
+        from hi.apps.config.signals import SettingsInitializer
+
+        # Populate the settings for all apps discovered to need them.
+        post_migrate.connect( lambda sender, **kwargs: SettingsInitializer().run( sender, **kwargs ),
+                              sender = self )
+        return
+    

--- a/src/hi/apps/config/signals.py
+++ b/src/hi/apps/config/signals.py
@@ -1,0 +1,105 @@
+import logging
+
+from django.db import transaction
+from django.apps import apps
+
+logger = logging.getLogger(__name__)
+
+
+class SettingsInitializer:
+    """ Ensure required configured setting DB records exist after migrations are applied. """
+
+    def run( self, sender, **kwargs ):
+        logger.debug( 'Populating initial DB records for settings.' )
+        app_settings_list = self._discover_app_settings()
+        self._create_settings( app_settings_list = app_settings_list )
+        return
+    
+    def _discover_app_settings( self ):
+        from hi.apps.common.module_utils import import_module_safe
+        from hi.apps.config.app_settings import AppSettings
+
+        app_settings_list = list()
+        for app_config in apps.get_app_configs():
+            if not app_config.name.startswith( 'hi' ):
+                continue
+            module_name = f'{app_config.name}.settings'
+            try:
+                app_module = import_module_safe( module_name = module_name )
+                if not app_module:
+                    continue
+
+                app_settings = AppSettings(
+                    app_name = app_config.name,
+                    app_module = app_module,
+                )
+                # Needs to have at least one Setting and one SettingDefinition
+                if len(app_settings) > 0:
+                    app_settings_list.append( app_settings )
+                
+            except Exception as e:
+                logger.exception( f'Problem loading settings for {module_name}.', e )
+            continue
+
+        return app_settings_list
+
+    def _create_settings( self, app_settings_list ):
+        with transaction.atomic():
+            for app_settings in app_settings_list:
+                _ = self._create_app_subsystem_if_needed( app_settings = app_settings )
+                continue
+        return
+    
+    def _create_app_subsystem_if_needed( self, app_settings ):
+        from hi.apps.config.models import Subsystem
+
+        try:
+            subsystem = Subsystem.objects.get( subsystem_key = app_settings.app_name )
+        except Subsystem.DoesNotExist:
+            subsystem = Subsystem.objects.create(
+                name = app_settings.label,
+                subsystem_key = app_settings.app_name,
+            )
+        self._create_attributes_if_needed(
+            subsystem = subsystem,
+            app_settings = app_settings,
+        )
+        return subsystem
+
+    def _create_attributes_if_needed( self, subsystem, app_settings ):
+        all_defined_setting_definitions_map = app_settings.all_setting_definitions()
+        
+        for setting_key, setting_definition in all_defined_setting_definitions_map.items():
+            _ = self._create_setting_attribute_if_needed(
+                subsystem = subsystem,
+                setting_key = setting_key,
+                setting_definition = setting_definition,
+            )
+            continue
+        return
+
+    def _create_setting_attribute_if_needed( self,
+                                             subsystem,
+                                             setting_key,
+                                             setting_definition ):
+        from hi.apps.attribute.enums import AttributeType
+        from hi.apps.config.models import SubsystemAttribute
+
+        try:
+            attribute = SubsystemAttribute.objects.get(
+                subsystem = subsystem,
+                setting_key = setting_key,
+            )
+        except SubsystemAttribute.DoesNotExist:
+            attribute = SubsystemAttribute.objects.create(
+                subsystem = subsystem,
+                setting_key = setting_key,
+                name = setting_definition.label,
+                value = setting_definition.initial_value,
+                value_type_str = str(setting_definition.value_type),
+                value_range_str = setting_definition.value_range_str,
+                attribute_type_str = AttributeType.PREDEFINED,
+                is_editable = setting_definition.is_editable,
+                is_required = setting_definition.is_required,
+            )
+        return attribute


### PR DESCRIPTION
## Pull Request: [Short Title]
To fix the first-time server startup errors.
 
### Issue Link
Closes #18 

---

## Category
<!-- Choose the type of change. -->
- [ X ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
<!-- Provide a summary of changes made in this PR. -->
The underlying issue was a race condition in populating the initial database records for the settings. On the first request, there are two threads and 3 background asyncio tasks racing to get a SettingsManager object. In the "ensure_initialized() method, it was doing an app discovery to find all settings and ensuring they were populated in the database with their initial values.  

Though there was thread locking to guard against the race condition, this did not guard against the three asyncio tasks from racing on the DB creation and it would deadlock or raise errors based on the initial request timing. Hence being hard to recreate in the dev environment, though seemed to always happen when running in Docker.

The solution was to re-think and re-do the necessity for doing this one-time DB record creation in the server.  While,guarding against asyncio tasks could have been added, the overall better solution is to get these in the database before the server is started for the first time.  Thus, we added a post_migrate() signal handler.

---

## How to Test
<!-- Provide steps to verify this PR -->
1. Wipe out the database and re-run migrations
2. Visit initial home/start page
3. Ensure no errors.

