### PR TITLE
Ensure service container restarts on reboot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,15 @@
 ## Pull Request: [Short Title]
-<!-- Describe the purpose of this PR in one or two sentences. -->
+
+
 
 ### Issue Link
-<!-- Reference any related issues using #123 -->
+
 Closes #ISSUE_NUMBER
 
 ---
 
 ## Category
-<!-- Choose the type of change. -->
+
 - [ ] **Feature** (New functionality)
 - [ ] **Bugfix** (Fixes an issue)
 - [ ] **Docs** (Documentation updates)
@@ -20,15 +21,15 @@ Closes #ISSUE_NUMBER
 ---
 
 ## Changes Summary
-<!-- Provide a summary of changes made in this PR. -->
-- [ ] Change 1
-- [ ] Change 2
-- [ ] Change 3
+
+- Change 1
+- Change 2
+- Change 3
 
 ---
 
 ## How to Test
-<!-- Provide steps to verify this PR -->
+
 1. Step 1
 2. Step 2
 3. Step 3
@@ -36,6 +37,7 @@ Closes #ISSUE_NUMBER
 ---
 
 ## Checklist
+
 - [ ] Code follows the project's style guidelines.
 - [ ] Unit tests added or updated if necessary.
 - [ ] All tests pass (`./manage.py test`).
@@ -45,17 +47,17 @@ Closes #ISSUE_NUMBER
 ---
 
 ## Related PRs
-<!-- If this PR is related to another PR, link it here. -->
+
 
 ---
 
 ## Screenshots (if applicable)
-<!-- Add screenshots to show UI changes. -->
+
 
 ---
 
 ## Additional Notes
-<!-- Any other context or concerns related to this PR. -->
+
 
 ---
 
@@ -66,5 +68,5 @@ Closes #ISSUE_NUMBER
 ---
 
 ### **Reviewer(s)**
-<!-- Tag specific people to review -->
+
 @cassandra

--- a/deploy/run_container.sh
+++ b/deploy/run_container.sh
@@ -26,7 +26,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -bg)
-            BACKGROUND_FLAGS="-d"
+            BACKGROUND_FLAGS="-d --restart unless-stopped"
             shift 1
             ;;
         *)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -107,6 +107,28 @@ export HI_EXTRA_HOST_URLS="${SCHEME}://${HOST}:${PORT}"
 ```
 If you want to use more than one url, put them all in there with a space between them. e.g., Adding one for the mnemonic host name and one for accessing through its IP address.
 
+#### Surviving Reboots
+
+If you deploy the service for continued use, you probably want to make sure it will restart if the server reboots. The `make docker-run` command is set up to tell Docker to restart on reboot, but that assumes Docker itself is set up to restart on reboots.
+
+##### MacOs
+
+Check that Docker will restart:
+```
+Docker Desktop > Go to Settings > General > Check "Start Docker Desktop when you log in".
+```
+
+##### Ubuntu (GNU/Linux)
+
+Check that Docker will restart: (want 'enabled')
+```
+systemctl is-enabled docker
+```
+If not, set to enabled with:
+```
+sudo systemctl enable docker
+```
+
 #### User Sign In
 
 If you have enabled requiring individual user logins, then you will need to create users manually. There is no general signup process through the app (currently), so all users need to be added using the administrator credentials using Django administrative pages.

--- a/docs/dev/ReleaseProcesses.md
+++ b/docs/dev/ReleaseProcesses.md
@@ -10,6 +10,9 @@
 - Get your `master` branch fully in sync with remote/upstream.
 - Merge from `staging` into `master`
 - Push `master` to remote/upstream.
-- Create GitHub release using that same tag.
-- Add tag with next version number in the form `vX.X.X`.
-- Add release notes: look at PR and commit histories.
+- Create GitHub release.
+- Add/create tag with next version number in the form `vX.X.X`.
+- Set Target = `master`
+- Use "Generate relewase notes" button anmd edit as needed.
+- Use "Set as the latest release" (usually)
+- "Publish Release" button.


### PR DESCRIPTION
## Pull Request: [Short Title]
Ensuring that the Docker container with Home Information service restarts if the machine it runs on reboots.  Applies to running it as a Docker background task.

### Issue Link
Closes #35 

---

## Category
<!-- Choose the type of change. -->
- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ X ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
<!-- Provide a summary of changes made in this PR. -->
- Added --restart option to run_container.sh helper script
- Updated Installation.md docs to mention this.
- Lingering minor doc changes for releases and pull request template.

---

## How to Test
<!-- Provide steps to verify this PR -->
1. Build and start the docker container `make docker-build ; make docker-run`
2. Verify flag set: `docker inspect --format='{{.HostConfig.RestartPolicy.Name}}' hi`

