### PR TITLE
Moved secrets for docker running into more persistent location.

### DIFF
--- a/deploy/run_container.sh
+++ b/deploy/run_container.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 HI_VERSION=$(cat HI_VERSION | tr -d '[:space:]')
-ENV_VAR_FILE=".private/env/local.env"
-DATA_DIR="${HOME}/.hi"
+HI_HOME="${HOME}/.hi"
+ENV_VAR_FILE="${HI_HOME}/env/local.env"
+DATA_DIR="${HI_HOME}"
 EXTERNAL_PORT=9411
 BACKGROUND_FLAGS=""
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -48,16 +48,15 @@ tar zxvf ~/Downloads/home-information-*.tar.gz
 
 #### Building
 
-Generate the environment variable file and review with the command below. The file will contain sensitive secrets and are stored in a `.private` directory. Also note that administrative credentials created during this next step and save them somewhere safe.
+Generate the environment variable file and review with the command below. The file will contain sensitive secrets and are stored in a `${HOME}/.hi/env` directory. Also note the administrative credentials created during this next step and can be found in that secrets file.
 ``` shell
 cd $PROJ_DIR/home-information*
 make env-build
 ```
 This generates an environment variable file used when running:
 ```
-$PROJ/.private/env/local.env
+$HOME/.hi/env/local.env
 ```
-This directory and its files should not be checked into the code repository. There is an existing `.gitignore` entry to prevent this.
 
 Build the Docker image. (This will take a while the first time.)
 ``` shell
@@ -97,7 +96,7 @@ With the server running, you are now ready to set up for your home's use.  See t
 
 ### Beyond localhost
 
-When you are ready to deploy this for access to other devices, some extra steps are needed.  Web browser and Django security models enforce strict checking of hostnames, so you may need to change some of your environment configurations in the file `$PROJ/.private/env/local.env`.
+When you are ready to deploy this for access to other devices, some extra steps are needed.  Web browser and Django security models enforce strict checking of hostnames, so you may need to change some of your environment configurations in the file `$HOME/.hi/env/local.env`.
 
 #### Allowed Hosts
 


### PR DESCRIPTION
## Pull Request: Docker env secrets file moved outside downloaded package area.

### Issue Link

Closes #37

---

## Category

- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ X ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Updated env-generate.py script to write to $HOME/.hi area
- Also refactored to better encapsulate env-dependent settings in env-generate.py
- Updated doc references to the secrets file.

---

## How to Test

1. Run `make env-build`
2. Ensure secrets file goes to `$HOME/.h/env/local.env`