### PR TITLE
Fix local timezone display in alert and weather templates (Issue #49)

### DIFF
--- a/src/hi/apps/alert/templates/alert/modals/alert_details.html
+++ b/src/hi/apps/alert/templates/alert/modals/alert_details.html
@@ -1,11 +1,13 @@
 {% extends "modals/action_done.html" %}
 {% load humanize %}
+{% load tz %}
 
 {% block title_text %}
 {{ alert.title }}
 {% endblock %}
 
 {% block body %}
+{% timezone USER_TIMEZONE %}
 <div>
   Alert Source: {{ alert.alarm_source.label }}
 </div>
@@ -16,7 +18,7 @@
   Alert Type: {{ alert.alarm_type }}
 </div>
 <div>
-  When: {{ alert.start_datetime|naturaltime }}
+  When: {{ alert.start_datetime|localtime|naturaltime }}
 </div>
 
 <div>
@@ -27,4 +29,5 @@
   {% include "alert/panes/alarm_details.html" %}
   {% endfor %}
 </div>
+{% endtimezone %}
 {% endblock %}

--- a/src/hi/apps/alert/templates/alert/panes/alarm_details.html
+++ b/src/hi/apps/alert/templates/alert/panes/alarm_details.html
@@ -1,6 +1,7 @@
+{% load tz %}
 <div>
   <div>
-    Alarmed at: {{ alarm.timestamp }}
+    Alarmed at: {{ alarm.timestamp|localtime }}
     {{ alarm.source_details_list|length }}
   </div>
   <div>

--- a/src/hi/apps/alert/templates/alert/panes/alarm_details.html
+++ b/src/hi/apps/alert/templates/alert/panes/alarm_details.html
@@ -1,4 +1,5 @@
 {% load tz %}
+{% timezone USER_TIMEZONE %}
 <div>
   <div>
     Alarmed at: {{ alarm.timestamp|localtime }}
@@ -13,3 +14,4 @@
     {% endfor %}
   </div>
 </div>
+{% endtimezone %}

--- a/src/hi/apps/alert/templates/alert/panes/alert_banner_content.html
+++ b/src/hi/apps/alert/templates/alert/panes/alert_banner_content.html
@@ -1,4 +1,6 @@
 {% load humanize %}
+{% load tz %}
+{% timezone USER_TIMEZONE %}
 <div class="hi-alert-banner-alert-list">
   {% for alert in alert_list %}
   <div class="hi-alert hi-alarm-level-{{ alert.alarm_level }} row">
@@ -9,7 +11,7 @@
     <div class="col-1">{{ alert.alarm_level.label }}</div>
     <div class="col-6">{{ alert.title }}</div>
     <div class="col-3">
-      Since {{ alert.start_datetime|naturaltime }}
+      Since {{ alert.start_datetime|localtime|naturaltime }}
     </div>
     <div class="col-1">
       <form action="{% url 'alert_acknowledge' alert_id=alert.id %}" method="post"
@@ -23,3 +25,4 @@
   <div class="alert alert-warning">No alerts.</div>
   {% endfor %}
 </div>
+{% endtimezone %}

--- a/src/hi/apps/weather/templates/weather/panes/weather_alerts.html
+++ b/src/hi/apps/weather/templates/weather/panes/weather_alerts.html
@@ -18,8 +18,8 @@
       <hr>
       <small>
         <strong>{{ weather_alert.event_type.label }}</strong> • {{ weather_alert.severity.label }} • 
-        Effective: {{ weather_alert.effective|date:"M j, Y g:i A" }}
-        {% if weather_alert.expires %} • Expires: {{ weather_alert.expires|date:"M j, Y g:i A" }}{% endif %}
+        Effective: {{ weather_alert.effective|localtime|date:"M j, Y g:i A" }}
+        {% if weather_alert.expires %} • Expires: {{ weather_alert.expires|localtime|date:"M j, Y g:i A" }}{% endif %}
       </small>
     </div>
 


### PR DESCRIPTION
## Summary
- Fixed alert details dialog to display times in local timezone instead of UTC
- Fixed alert banner to display times in local timezone instead of UTC  
- Fixed weather alert effective/expires times to display in local timezone instead of UTC
- Applied proper timezone context and localtime filters following existing codebase patterns

## Changes Made
- **alert/modals/alert_details.html**: Added `{% load tz %}` and `{% timezone USER_TIMEZONE %}` context, converted `alert.start_datetime` to use `|localtime|naturaltime`
- **alert/panes/alarm_details.html**: Added `{% load tz %}` and converted `alarm.timestamp` to use `|localtime`
- **alert/panes/alert_banner_content.html**: Added `{% load tz %}` and `{% timezone USER_TIMEZONE %}` context, converted `alert.start_datetime` to use `|localtime|naturaltime`
- **weather/panes/weather_alerts.html**: Fixed `weather_alert.effective` and `weather_alert.expires` to use `|localtime|date:`

## Test Plan
- [x] Generated alerts and verified local timezone display in details dialog
- [x] Ran alert app unit tests - all 33 tests pass
- [x] Ran weather app unit tests - all 220 tests pass
- [x] Verified existing templates with proper timezone handling remain unchanged

## Technical Details
All fixes follow the established codebase pattern:
1. Load timezone template tags with `{% load tz %}`
2. Wrap content in `{% timezone USER_TIMEZONE %}...{% endtimezone %}`  
3. Apply `|localtime` filter before other datetime filters like `|naturaltime` or `|date:`

Closes #49