### PR TITLE
Fix textarea auto-resize for new attribute creation

### DIFF
--- a/src/hi/apps/attribute/templates/attribute/panes/attribute_form_new.html
+++ b/src/hi/apps/attribute/templates/attribute/panes/attribute_form_new.html
@@ -40,6 +40,19 @@
 
   </div>
 
+<script type="text/javascript">
+(function() {
+   let textareaSelector = '#{{ attribute_form.value.id_for_label }}';
+   autosize($(textareaSelector));
+
+   // In case this is in a modal, need to wait for autosize to work.
+   $('.modal').on('shown.bs.modal', function () {
+     autosize.update($(textareaSelector));
+   });
+ })();
+
+</script>
+
   <span>
     <input type="checkbox" name="{{ attribute_form.secret.html_name }}"
 	   id="{{ attribute_form.secret.id_for_label }}"


### PR DESCRIPTION
## Summary
- Fixed textarea auto-resize issue in Add New Attribute modal dialog
- Added missing autosize JavaScript initialization to new attribute textarea template
- Ensures consistent behavior between existing and new attribute textareas

## Root Cause
The textarea in the "Add New Attribute" section was missing the autosize JavaScript initialization that existing attribute textareas had. This caused new attribute textareas to remain fixed height when typing multi-line content.

## Changes Made
- Modified `src/hi/apps/attribute/templates/attribute/panes/attribute_form_new.html`
- Added autosize JavaScript using the same pattern as existing working textareas
- Included modal dialog handling for proper initialization timing

## Test Plan
- [x] Verified the JavaScript pattern matches the working implementation in `attribute_form_field_value.html`
- [x] Tested the fix targets the exact textarea mentioned in the issue (new attribute creation)
- [ ] Manual testing: Open entity edit modal, click "Add New Attribute", type multi-line text and verify textarea expands

## Issue Resolution
Fixes #1 - Attribute TextArea Not Dynamically Growing

The implementation follows the existing codebase patterns and uses the same autosize library already loaded globally.