### PR TITLE
Fix sunrise/sunset display in weather overview sidebar

### DIFF
--- a/src/hi/apps/weather/weather_manager.py
+++ b/src/hi/apps/weather/weather_manager.py
@@ -132,7 +132,7 @@ class WeatherManager( Singleton, SettingsMixin, AlertMixin ):
     def get_weather_overview_data(self) -> WeatherOverviewData:
         return WeatherOverviewData(
             current_conditions_data = self.get_current_conditions_data(),
-            todays_astronomical_data = self.get_daily_astronomical_data,
+            todays_astronomical_data = self.get_todays_astronomical_data(),
         )
     
     def get_hourly_forecast(self) -> HourlyForecast:


### PR DESCRIPTION
## Pull Request: Fix Sunrise/Sunset Display in Weather Overview Sidebar

### Issue Link
Closes #170

### Summary
- Fixed critical bug in `weather_manager.py` causing sunrise/sunset values to display as '--'
- Root cause was missing method call parentheses and wrong method name in `get_weather_overview_data()`
- Changed from `self.get_daily_astronomical_data` to `self.get_todays_astronomical_data()`
- This ensures the template receives proper `AstronomicalData` structure instead of method reference

### Technical Details
The weather overview sidebar and astronomical details modal both use the same template (`astronomical_brief.html`) but were getting different data structures:
- **Working modal**: Uses `get_todays_astronomical_data()` → returns `AstronomicalData`
- **Broken sidebar**: Was using `get_daily_astronomical_data` (no parentheses) → returns method reference

Template expects `astronomical_data.sunrise.value` but was getting a method reference instead of sunrise data.

### Testing  
- [x] Unit tests pass (`make test`)
- [x] Code quality check passes (`make lint`) 
- [x] Verified fix resolves the specific issue described
- [x] Both sidebar and modal astronomical data display should now work correctly

### Files Changed
- `src/hi/apps/weather/weather_manager.py`: Fixed method call in `get_weather_overview_data()`

### Code Change
```python
# Before (broken)
todays_astronomical_data = self.get_daily_astronomical_data,

# After (fixed) 
todays_astronomical_data = self.get_todays_astronomical_data(),
```