### PR TITLE
Added audio test button to audio config settings page

### DIFF
--- a/src/hi/apps/attribute/templates/attribute/components/regular_attribute_list.html
+++ b/src/hi/apps/attribute/templates/attribute/components/regular_attribute_list.html
@@ -5,12 +5,14 @@
   <h6 class="attr-v2-section-title">{{ title }}</h6>
   {% endif %}
 
+  {% if regular_attributes_formset.non_form_errors %}
   <div class="attr-v2-formset-errors"
        style="width: 450px; overflow: hidden; word-wrap: break-word;">
     {% for err in regular_attributes_formset.non_form_errors %}
     <div class="attr-v2-error-item" style="word-break: break-word;">{{ err }}</div>
     {% endfor %}
   </div>
+  {% endif %}
   
   <div class="attr-v2-attribute-list">
     {% for attribute_form in regular_attributes_formset %}

--- a/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
+++ b/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
@@ -10,23 +10,15 @@ This is what gets replaced on form submission
 {% block basic_info %}{% endblock %}
 
 {% block additional_actions %}
-<div class="d-flex align-items-center">
-  <button type="button"
-          class="btn btn-outline-primary btn-sm mr-3"
-          onclick="Hi.audio.testAudio();"
-          title="Test audio playback">
-    {% icon "play" size="sm" css_class="hi-icon-left" %}Test Audio
-  </button>
-  <h4 class="mb-0 text-muted {{ DIVID.ATTR_V2_FORM_DISPLAY_LABEL_CLASS }}">
-    {% for multi_edit_form_data in multi_edit_form_data_list %}
-      {% if selected_subsystem_id == multi_edit_form_data.owner.id|stringformat:'s' %}
-        {{ multi_edit_form_data.owner.name }} Settings
-      {% endif %}
-    {% empty %}
-      System Settings
-    {% endfor %}
-  </h4>
-</div>
+<h4 class="mb-0 text-muted {{ DIVID.ATTR_V2_FORM_DISPLAY_LABEL_CLASS }}">
+  {% for multi_edit_form_data in multi_edit_form_data_list %}
+    {% if selected_subsystem_id == multi_edit_form_data.owner.id|stringformat:'s' %}
+      {{ multi_edit_form_data.owner.name }} Settings
+    {% endif %}
+  {% empty %}
+    System Settings
+  {% endfor %}
+</h4>
 {% endblock %}
 
 {% block file_upload_button %}{% endblock %}
@@ -70,6 +62,17 @@ This is what gets replaced on form submission
     
     <!-- Subsystem content using existing attribute editing components -->
     <div class="py-3">
+      {% if multi_edit_form_data.owner.subsystem_key == "hi.apps.audio" %}
+      <!-- Audio Test Button - only shown for Audio subsystem -->
+      <div class="mb-3">
+        <button type="button"
+                class="btn btn-outline-primary btn-xs"
+                onclick="Hi.audio.testAudio();"
+                title="Test audio playback">
+          {% icon "play" size="xs" css_class="hi-icon-left" %}Test Audio
+        </button>
+      </div>
+      {% endif %}
       {% include "attribute/components/regular_attribute_list.html" with regular_attributes_formset=multi_edit_form_data.formset attr_item_context=multi_edit_form_data.context %}
     </div>
     

--- a/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
+++ b/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
@@ -10,15 +10,23 @@ This is what gets replaced on form submission
 {% block basic_info %}{% endblock %}
 
 {% block additional_actions %}
-<h4 class="mb-0 text-muted {{ DIVID.ATTR_V2_FORM_DISPLAY_LABEL_CLASS }}">
-  {% for multi_edit_form_data in multi_edit_form_data_list %}
-    {% if selected_subsystem_id == multi_edit_form_data.owner.id|stringformat:'s' %}
-      {{ multi_edit_form_data.owner.name }} Settings
-    {% endif %}
-  {% empty %}
-    System Settings
-  {% endfor %}
-</h4>
+<div class="d-flex align-items-center">
+  <button type="button"
+          class="btn btn-outline-primary btn-sm mr-3"
+          onclick="Hi.audio.testAudio();"
+          title="Test audio playback">
+    {% icon "play" size="sm" css_class="hi-icon-left" %}Test Audio
+  </button>
+  <h4 class="mb-0 text-muted {{ DIVID.ATTR_V2_FORM_DISPLAY_LABEL_CLASS }}">
+    {% for multi_edit_form_data in multi_edit_form_data_list %}
+      {% if selected_subsystem_id == multi_edit_form_data.owner.id|stringformat:'s' %}
+        {{ multi_edit_form_data.owner.name }} Settings
+      {% endif %}
+    {% empty %}
+      System Settings
+    {% endfor %}
+  </h4>
+</div>
 {% endblock %}
 
 {% block file_upload_button %}{% endblock %}

--- a/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
+++ b/src/hi/apps/config/templates/config/panes/subsystem_edit_content_body.html
@@ -61,10 +61,10 @@ This is what gets replaced on form submission
        aria-labelledby="subsystem-{{ multi_edit_form_data.owner.id }}-tab">
     
     <!-- Subsystem content using existing attribute editing components -->
-    <div class="py-3">
+    <div class="">
       {% if multi_edit_form_data.owner.subsystem_key == "hi.apps.audio" %}
       <!-- Audio Test Button - only shown for Audio subsystem -->
-      <div class="mb-3">
+      <div class="mb-3 text-right">
         <button type="button"
                 class="btn btn-outline-primary btn-xs"
                 onclick="Hi.audio.testAudio();"

--- a/src/hi/apps/config/tests/test_views.py
+++ b/src/hi/apps/config/tests/test_views.py
@@ -150,4 +150,22 @@ class TestConfigSettingsView(DualModeViewTestCase):
         # There may be default system subsystems in addition to our test subsystem
         self.assertGreaterEqual(len(form_data_list), 1)  # At least our test subsystem
 
+    def test_audio_test_button_appears(self):
+        """Test that the Test Audio button appears in the settings page template."""
+        url = reverse('config_settings')
+        response = self.client.get(url)
+
+        self.assertSuccessResponse(response)
+        self.assertHtmlResponse(response)
+
+        # Check that the Test Audio button is present in the rendered HTML
+        content = response.content.decode('utf-8')
+        self.assertIn('Test Audio', content)
+        self.assertIn('Hi.audio.testAudio()', content)
+        self.assertIn('btn-outline-primary', content)
+
+        # Verify the button has proper attributes
+        self.assertIn('type="button"', content)
+        self.assertIn('title="Test audio playback"', content)
+
 

--- a/src/hi/static/js/audio.js
+++ b/src/hi/static/js/audio.js
@@ -117,12 +117,12 @@
         return `${SignalAudioIdPrefix}-${signalName}`;
     }
     
-    function _startAudibleSignal( signalName ) {
-        if ( Hi.DEBUG ) { console.log( `Starting audio signal = ${signalName}` ); }
+    function _startAudibleSignal( signalName, forcePlay = false ) {
+        if ( Hi.DEBUG ) { console.log( `Starting audio signal = ${signalName}, forcePlay = ${forcePlay}` ); }
         try {
             stopAudio( );
             clearAudibleSignalTimer();
-            if ( ! Hi.settings.isAudioEnabled() ) {
+            if ( ! forcePlay && ! Hi.settings.isAudioEnabled() ) {
                 if ( Hi.DEBUG ) { console.log( `Audio disabled, not playing signal: ${signalName}` ); }
                 return;
             }
@@ -645,16 +645,16 @@
     */
 
     function _testAudio() {
-        if (Hi.DEBUG) { console.log('Testing audio with ConsoleInfo signal'); }
+        if (Hi.DEBUG) { console.log('Testing audio with ConsoleInfo signal (bypassing audio enabled setting)'); }
 
-        // Use the softer ConsoleInfo signal as requested
-        _startAudibleSignal('ConsoleInfo');
+        // Use forcePlay=true to bypass audio enabled setting for testing
+        _startAudibleSignal('ConsoleInfo', true);
 
-        // The _startAudibleSignal function already handles:
-        // - Audio disabled check
+        // The _startAudibleSignal function handles:
         // - Missing audio elements
         // - Autoplay restrictions with user feedback
         // - All error cases with appropriate logging
+        // - Audio enabled setting (bypassed with forcePlay=true)
     }
 
     // Initialize systems when audio module loads

--- a/src/hi/static/js/audio.js
+++ b/src/hi/static/js/audio.js
@@ -25,6 +25,11 @@
             return _handleAudioButtonClick();
         },
         
+        // Audio testing method for configuration pages
+        testAudio: function() {
+            _testAudio();
+        },
+
         // Initialization
         init: function() {
             startAudioPolling();
@@ -630,6 +635,26 @@
             diagnosticCounter = 0;
             if (Hi.DEBUG) { console.log('🔇 Diagnostic background audio stopped'); }
         }
+    }
+
+    /*
+      AUDIO TESTING FOR CONFIGURATION PAGES
+
+      - Provides a simple test function to play a soft audio signal
+      - Uses existing audio infrastructure and error handling
+    */
+
+    function _testAudio() {
+        if (Hi.DEBUG) { console.log('Testing audio with ConsoleInfo signal'); }
+
+        // Use the softer ConsoleInfo signal as requested
+        _startAudibleSignal('ConsoleInfo');
+
+        // The _startAudibleSignal function already handles:
+        // - Audio disabled check
+        // - Missing audio elements
+        // - Autoplay restrictions with user feedback
+        // - All error cases with appropriate logging
     }
 
     // Initialize systems when audio module loads


### PR DESCRIPTION
## Pull Request: Added audio test button to audio config settings page

### Issue Link

Closes #196

---

## Category

- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Added "Test Audio" button to audio subsystem configuration page
- Button uses existing audio infrastructure to play ConsoleInfo signal for testing
- Positioned button within audio tab content (not global header)
- Added forcePlay parameter to bypass audio disabled setting for testing purposes
- Included template test coverage for button presence and functionality

---

## How to Test

1. Navigate to Configuration → Audio settings tab
2. Verify "Test Audio" button appears only in Audio subsystem (not other tabs)
3. Click "Test Audio" button - should play audio even if console sounds are disabled
4. Test with audio enabled/disabled in settings - button should work in both cases
5. Verify button has proper styling and icon

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

None

---

## Screenshots (if applicable)

None required - UI enhancement follows existing patterns

---

## Additional Notes

This feature addresses browser audio diagnostic challenges by providing users an easy way to test their audio setup using the softer ConsoleInfo sound. The implementation leverages existing audio infrastructure with minimal code changes and maintains backward compatibility.

Key implementation details:
- Uses subsystem_key check instead of hard-coded IDs
- Employs forcePlay parameter to bypass audio settings for testing
- Maintains all existing audio permission handling and user feedback
- Clean, well-factored solution without code duplication

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
