### PR TITLE
Fix Collection button highlighting in LocationView

### DIFF
--- a/src/hi/apps/location/views.py
+++ b/src/hi/apps/location/views.py
@@ -115,9 +115,8 @@ class LocationItemStatusView( View, LocationViewMixin, EntityViewMixin ):
     
         elif item_type == ItemType.COLLECTION:
             url = reverse( 'collection_view', kwargs = { 'collection_id': item_id } )
-            javascript_payload = f"window.location.href = '{url}';"
-            return HttpResponse(javascript_payload, content_type="application/javascript")
-
+            return antinode.redirect_response( url )
+        
         raise BadRequest( f'Unknown item type "{item_type}".' )
         
     def _handle_entity(self, request : HttpRequest, entity : Entity ):


### PR DESCRIPTION
## Pull Request: Fix Collection button highlighting in LocationView



### Issue Link

Closes https://github.com/cassandra/home-information/issues/200

---

## Category

- [ ] **Feature** (New functionality)
- [X] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ]  **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- In visual mode, redirecting to Hi.API_LOCATION_ITEM_STATUS_URL/<svgItemId> instead of performing an AJAX request.

- Maintaining the existing AJAX behavior in edit mode.

- Ensuring button highlighting is consistent with the currently displayed content.

---

## How to Test

1. Ensure there is at least one **Collection** defined that is visible in a **LocationView**.
2. Navigate to the **LocationView** page where the collection is displayed.
3. Click on the **Collection item/icon** within the LocationView.
4. Verify that the main content switches to the **Collection view**.
5. Confirm that:
   - The previously active **LocationView button** at the top is no longer highlighted.
   - The **Collection button** at the bottom is now highlighted in orange (btn-secondary).
6. Repeat the test by clicking on other collections (if available) to ensure consistent button highlighting.
7. Ensure that **edit mode** behavior remains unchanged (AJAX request should still be used, without full page reload).


---

## Checklist

- [X] Code follows the project's style guidelines.
- [X] Unit tests added or updated if necessary.
- [X] All tests pass (`./manage.py test`).
- [X] Docs updated if applicable.
- [X] No breaking changes introduced.

---

## Related PRs


---

## Screenshots (if applicable)


---

## Additional Notes

When clicking on a Collection item from within a LocationView, the main content correctly switches to the Collection view. However, the UI buttons for the top LocationView and bottom CollectionView did not reflect this change — the previously active LocationView button remained highlighted, and the currently active CollectionView button was not highlighted.

This PR updates the handleSvgPathClick function to use a synchronous navigation for Collection items when not in edit mode. By navigating directly to the Collection view URL, the middleware updates the active_collection parameter, ensuring that both the top and bottom buttons correctly reflect the current view.


---

### **Ready for Review?**
- [X] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
