### PR TITLE
created an alfabetical order of the subsystem settings in the tabbed panels

### DIFF
--- a/src/hi/apps/config/settings_manager.py
+++ b/src/hi/apps/config/settings_manager.py
@@ -41,6 +41,7 @@ class SettingsManager( Singleton ):
     
     def reload(self):
         with self._attributes_lock:
+            self._subsystem_list = sorted(self._subsystem_list, key=lambda s: s.name)
             self._attribute_value_map = dict()
             for subsystem in self._subsystem_list:
                 try:


### PR DESCRIPTION
## Pull Request: Deterministic Ordering of Subsystem Settings Panels

### Issue Link

Closes #143 

---

## Category

- [X] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)

- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Added deterministic ordering to `SettingsManager.reload()`.
- Sorted the subsystem list (`self._subsystem_list`) before attribute extraction
- Ensured predictable ordering in the tabbed settings panel UI

---

## How to Test

1. Start the application and navigate to the Settings page
2. Observe the Subsystem tab order before applying the patch (non-deterministic or inconsistent).
3. Apply this branch and reload the page.
4. Confirm that subsystem tabs now appear in deterministic alphabetical order (or the defined sort criterion).
5. Run `./manage.py` test to ensure existing logic remains unaffected.

---

## Checklist

- [X] Code follows the project's style guidelines.
- [ ] Unit tests added or updated if necessary.
- [X] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [X] No breaking changes introduced.

---

### **Ready for Review?**
- [X] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
