### PR TITLE
Feature/33 Dynamic initial entity sizing

### DIFF
--- a/src/hi/apps/entity/entity_manager.py
+++ b/src/hi/apps/entity/entity_manager.py
@@ -7,7 +7,6 @@ from django.db import transaction
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
-from hi.apps.common.svg_models import SvgItemPositionBounds
 from hi.apps.common.singleton import Singleton
 from hi.apps.location.path_geometry import PathGeometry
 from hi.apps.entity.edit.forms import EntityPositionForm
@@ -39,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 class EntityManager(Singleton):
 
-    DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX = 20.0
+    DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX = 10.0
 
     def __init_singleton__(self):
         self._change_listeners = list()
@@ -227,27 +226,22 @@ class EntityManager(Singleton):
         )
         return entity_position
 
-    def _get_default_icon_scale( self, entity: Entity, location_view: LocationView ) -> Decimal:
+    def _get_default_icon_scale( self,
+                                 entity         : Entity,
+                                 location_view  : LocationView ) -> Decimal:
         view_box = location_view.svg_view_box
         icon_view_box = EntityStyle.get_svg_icon_viewbox( entity.entity_type )
 
         icon_max_dimension = max( icon_view_box.width, icon_view_box.height )
         if icon_max_dimension <= 0:
-            return Decimal( 1.0 )
+            return Decimal( '1.0' )
 
-        target_icon_size = min( view_box.width, view_box.height ) * (
-            self.DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX / 100.0
-        )
+        viewbox_min_dimension = min( view_box.width, view_box.height )
+        size_fraction = self.DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX / 100.0
+        target_icon_size = viewbox_min_dimension * size_fraction
         scale = target_icon_size / icon_max_dimension
-        
-        position_bounds = SvgItemPositionBounds(
-            min_x = view_box.x,
-            min_y = view_box.y,
-            max_x = view_box.x + view_box.width,
-            max_y = view_box.y + view_box.height,
-            min_scale = 0.1,
-            max_scale = 25.0,
-        )
+
+        position_bounds = location_view.location.svg_position_bounds
         scale = max( position_bounds.min_scale, min( scale, position_bounds.max_scale ) )
 
         return Decimal( str(scale) )
@@ -440,13 +434,14 @@ class EntityManager(Singleton):
         
         # Preserve EntityPath and create/update EntityPosition
         # This allows easy reversion when users change their mind
+        svg_scale = self._get_default_icon_scale( entity, location_view )
         entity_position, created = EntityPosition.objects.get_or_create(
             entity = entity,
             location = location_view.location,
             defaults = {
                 'svg_x': Decimal(center_x),
                 'svg_y': Decimal(center_y),
-                'svg_scale': Decimal(1.0),
+                'svg_scale': svg_scale,
                 'svg_rotate': Decimal(0.0),
             }
         )

--- a/src/hi/apps/entity/tests/test_entity_manager.py
+++ b/src/hi/apps/entity/tests/test_entity_manager.py
@@ -344,8 +344,11 @@ class TestEntityManager(BaseTestCase):
                 integration_name='test_integration',
             )
             
-            location = Location.objects.create(name='Test Location')
-            
+            location = Location.objects.create(
+                name = 'Test Location',
+                svg_view_box_str = '100 200 400 300',
+            )
+
             # Create a mock location view with known view box
             view_box = SvgViewBox(x=100, y=200, width=400, height=300)
             location_view = Mock()
@@ -366,8 +369,7 @@ class TestEntityManager(BaseTestCase):
             self.assertEqual(entity_position.location, location)
             self.assertEqual(entity_position.svg_x, expected_x)
             self.assertEqual(entity_position.svg_y, expected_y)
-            # Default icon size should be tied to viewBox size using manager config.
-            # Camera icon viewBox max dimension is 64 (from hi_styles).
+            # Default icon size should be a percentage of the viewBox's smaller dimension.
             expected_scale = (
                 Decimal('300')
                 * Decimal(str(manager.DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX))
@@ -391,5 +393,51 @@ class TestEntityManager(BaseTestCase):
             
         except ImportError:
             self.skipTest("Location models not available for testing")
+        return
+
+    def _create_scale_test_fixtures( self, viewbox_width, viewbox_height ):
+        from hi.apps.common.svg_models import SvgViewBox
+        from hi.apps.location.models import Location
+
+        entity = Entity.objects.create(
+            name = 'Scale Test Entity',
+            entity_type_str = str( EntityType.CAMERA ),
+        )
+        location = Location.objects.create(
+            name = 'Test Location',
+            svg_view_box_str = f'0 0 {viewbox_width} {viewbox_height}',
+        )
+        location_view = Mock()
+        location_view.location = location
+        location_view.svg_view_box = SvgViewBox(
+            x = 0, y = 0, width = viewbox_width, height = viewbox_height,
+        )
+        return entity, location, location_view
+
+    def test_get_default_icon_scale_zero_viewbox(self):
+        """Scale should clamp to min_scale when viewbox has zero dimension."""
+        manager = EntityManager()
+        entity, location, location_view = self._create_scale_test_fixtures( 0, 0 )
+
+        scale = manager._get_default_icon_scale( entity, location_view )
+        self.assertEqual( scale, Decimal( str( location.svg_position_bounds.min_scale ) ) )
+        return
+
+    def test_get_default_icon_scale_very_large_viewbox(self):
+        """Scale should clamp to max_scale for extremely large viewboxes."""
+        manager = EntityManager()
+        entity, location, location_view = self._create_scale_test_fixtures( 100000, 100000 )
+
+        scale = manager._get_default_icon_scale( entity, location_view )
+        self.assertEqual( scale, Decimal( str( location.svg_position_bounds.max_scale ) ) )
+        return
+
+    def test_get_default_icon_scale_very_small_viewbox(self):
+        """Scale should clamp to min_scale for tiny viewboxes."""
+        manager = EntityManager()
+        entity, location, location_view = self._create_scale_test_fixtures( 10, 10 )
+
+        scale = manager._get_default_icon_scale( entity, location_view )
+        self.assertEqual( scale, Decimal( str( location.svg_position_bounds.min_scale ) ) )
         return
 


### PR DESCRIPTION
## Pull Request: Scale new entity icons relative to LocationView viewBox

### Issue Link

Closes #33 

---

## Category

- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)

- [x] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Added logic to compute the default `svg_scale` of a newly created `EntityPosition` based on the current `LocationView` viewBox.
- Implemented `_get_default_icon_scale()` in `EntityManager` to size icons as a fixed percentage of the viewBox.
- Introduced `DEFAULT_ICON_SIZE_PERCENT_OF_VIEWBOX` constant (20%) to control the initial icon size relative to the viewBox.
- Calculated scale using the SVG icon's own viewBox to ensure consistent sizing across different icon shapes.
- Added scale bounds using `SvgItemPositionBounds` to prevent extremely small or large icon scales.
- Replaced the previous fixed `svg_scale = 1.0` behavior when creating new entity positions.
- Updated tests to validate that the default icon scale is derived from the viewBox size rather than a fixed value.

---

## How to Test

1. Open a `Location View` in editing mode.
2. Add a new entity item to the view.
3. Verify that the icon appears at a reasonable and visible size regardless of the viewBox dimensions.
4. Repeat the test with Location Views that have significantly different viewBox sizes to confirm that the icon size scales consistently.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra