### PR TITLE
Disable jQuery Automatic Script Evaluation (Issue #245)

### DIFF
--- a/src/hi/static/js/antinode.js
+++ b/src/hi/static/js/antinode.js
@@ -944,6 +944,19 @@ function csrfSafeMethod(method) {
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 $.ajaxSetup({
+    // Disable jQuery's automatic script evaluation for security and explicit control flow.
+    // This prevents jQuery from auto-executing responses with Content-Type: application/javascript.
+    // All script execution should be done explicitly through antinode patterns (e.g., redirect_response).
+    contents: {
+        script: false
+    },
+    converters: {
+        "text script": function(text) {
+            // Don't auto-execute - return as plain text.
+            // If script execution is needed, use explicit eval or antinode patterns.
+            return text;
+        }
+    },
     beforeSend: function(xhr, settings) {
         if ( csrfSafeMethod( settings.type ) ) {
             return;


### PR DESCRIPTION
## Pull Request: Disable jQuery Automatic Script Evaluation

### Issue Link
Closes #245

---

## Category
- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [x] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary
Add `contents` and `converters` properties to `$.ajaxSetup()` in `antinode.js` to disable jQuery's automatic script execution for responses with `Content-Type: application/javascript`. All script execution in this app is done explicitly through antinode patterns, making the automatic evaluation both unnecessary and a security concern.

---

## How to Test
1. Verify all AJAX operations work as before (modal loading, form submissions, entity editing, integration sync)
2. No behavioral change expected — this only disables an unused jQuery feature

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
