### PR TITLE
Feature/220 Adding Screen Auto-Lock for Away Mode

### DIFF
--- a/src/hi/apps/api/tests/test_views.py
+++ b/src/hi/apps/api/tests/test_views.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from django.urls import reverse
 
+from hi.apps.console.constants import ConsoleConstants
 from hi.testing.view_test_base import AsyncViewTestCase
 
 logging.disable(logging.CRITICAL)
@@ -31,6 +32,29 @@ class TestStatusView(AsyncViewTestCase):
         self.assertIn('cssClassUpdateMap', data)
         self.assertIn('idReplaceUpdateMap', data)
         self.assertIn('idReplaceHashMap', data)
+        self.assertIn('consoleLocked', data)
+
+    def test_status_view_reports_console_locked_false_by_default(self):
+        """Test that status response defaults consoleLocked to False."""
+        url = reverse('api_status')
+        response = self.async_get(url)
+
+        self.assertSuccessResponse(response)
+        data = response.json()
+        self.assertFalse(data['consoleLocked'])
+
+    def test_status_view_reports_console_locked_true_when_session_locked(self):
+        """Test that status response reflects session lock state."""
+        session = self.client.session
+        session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] = True
+        session.save()
+
+        url = reverse('api_status')
+        response = self.async_get(url)
+
+        self.assertSuccessResponse(response)
+        data = response.json()
+        self.assertTrue(data['consoleLocked'])
 
     def test_status_view_timestamp_format(self):
         """Test that timestamps in status response are properly formatted."""

--- a/src/hi/apps/api/views.py
+++ b/src/hi/apps/api/views.py
@@ -11,6 +11,7 @@ from django.views.generic import View
 from hi.apps.alert.alert_mixins import AlertMixin
 import hi.apps.common.datetimeproxy as datetimeproxy
 from hi.apps.config.settings_mixins import SettingsMixin
+from hi.apps.console.constants import ConsoleConstants
 from hi.apps.console.console_mixins import ConsoleMixin
 from hi.apps.console.transient_view_manager import TransientViewManager
 from hi.apps.monitor.status_display_manager import StatusDisplayManager
@@ -35,6 +36,7 @@ class StatusView( View,
     CssClassUpdateMapAttr = 'cssClassUpdateMap'
     IdReplaceUpdateMapAttr = 'idReplaceUpdateMap'
     IdReplaceHashMapAttr = 'idReplaceHashMap'
+    ConsoleLockedAttr = 'consoleLocked'
     TransientViewSuggestionAttr = 'transientViewSuggestion'
     TransientViewUrlAttr = 'url'
     TransientViewDurationSecondsAttr = 'durationSeconds'
@@ -91,6 +93,10 @@ class StatusView( View,
             self.CssClassUpdateMapAttr: css_class_update_map,
             self.IdReplaceUpdateMapAttr: id_replace_map,
             self.IdReplaceHashMapAttr: id_replace_hash_map,
+            self.ConsoleLockedAttr: request.session.get(
+                ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR,
+                False,
+            ),
         }
         
         if suggestion:

--- a/src/hi/apps/console/constants.py
+++ b/src/hi/apps/console/constants.py
@@ -1,4 +1,5 @@
 class ConsoleConstants:
 
     CONSOLE_LOCKED_SESSION_VAR = 'console_locked'
+    CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR = 'console_away_auto_lock_version'
     DATETIME_HEADER_TEMPLATE_NAME = 'console/panes/datetime_header.html'

--- a/src/hi/apps/console/middleware.py
+++ b/src/hi/apps/console/middleware.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 
+from hi.apps.security.security_manager import SecurityManager
+
 from .constants import ConsoleConstants
 from .views import ConsoleUnlockView
 
@@ -23,11 +25,32 @@ class ConsoleLockMiddleware:
         return self.process_response( request, response )
 
     def process_request( self, request ):
+        self._process_away_auto_lock( request )
+
         if request.session.get( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, False ):
             if request.path in self.EXCLUDED_PATHS:
                 return None
             return ConsoleUnlockView().get( request )
         return None
+
+    def _process_away_auto_lock( self, request ):
+        auto_lock_version = SecurityManager().get_console_away_auto_lock_version()
+        if not auto_lock_version:
+            return
+
+        previous_auto_lock_version = request.session.get(
+            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR
+        )
+        if str(previous_auto_lock_version) == str(auto_lock_version):
+            return
+
+        request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR] = str(auto_lock_version)
+
+        if request.session.get( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, False ):
+            return
+
+        request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] = True
+        return
     
     def process_response(self, request, response):
         return response

--- a/src/hi/apps/console/middleware.py
+++ b/src/hi/apps/console/middleware.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from .console_helper import ConsoleSettingsHelper
 from hi.apps.security.security_manager import SecurityManager
 
 from .constants import ConsoleConstants
@@ -47,6 +48,10 @@ class ConsoleLockMiddleware:
         request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR] = str(auto_lock_version)
 
         if request.session.get( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, False ):
+            return
+
+        lock_password = ConsoleSettingsHelper().get_console_lock_password()
+        if not lock_password:
             return
 
         request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] = True

--- a/src/hi/apps/console/middleware.py
+++ b/src/hi/apps/console/middleware.py
@@ -1,8 +1,9 @@
+from django.http import HttpRequest
 from django.urls import reverse
 
-from .console_helper import ConsoleSettingsHelper
 from hi.apps.security.security_manager import SecurityManager
 
+from .console_helper import ConsoleSettingsHelper
 from .constants import ConsoleConstants
 from .views import ConsoleUnlockView
 
@@ -34,7 +35,7 @@ class ConsoleLockMiddleware:
             return ConsoleUnlockView().get( request )
         return None
 
-    def _process_away_auto_lock( self, request ):
+    def _process_away_auto_lock( self, request : HttpRequest ) -> None:
         auto_lock_version = SecurityManager().get_console_away_auto_lock_version()
         if not auto_lock_version:
             return
@@ -42,10 +43,10 @@ class ConsoleLockMiddleware:
         previous_auto_lock_version = request.session.get(
             ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR
         )
-        if str(previous_auto_lock_version) == str(auto_lock_version):
+        if str( previous_auto_lock_version ) == str( auto_lock_version ):
             return
 
-        request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR] = str(auto_lock_version)
+        request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR] = str( auto_lock_version )
 
         if request.session.get( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, False ):
             return
@@ -56,6 +57,6 @@ class ConsoleLockMiddleware:
 
         request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] = True
         return
-    
+
     def process_response(self, request, response):
         return response

--- a/src/hi/apps/console/tests/test_console_lock_middleware.py
+++ b/src/hi/apps/console/tests/test_console_lock_middleware.py
@@ -26,8 +26,10 @@ class TestConsoleLockMiddleware(BaseTestCase):
         request.session = {}
 
         with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleSettingsHelper.get_console_lock_password') as mock_get_lock_password, \
              patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+            mock_get_lock_password.return_value = 'secret'
 
             mock_unlock_view = Mock()
             mock_unlock_response = HttpResponse('locked', status=403)
@@ -97,4 +99,47 @@ class TestConsoleLockMiddleware(BaseTestCase):
 
             self.assertIsNone(response)
             self.assertNotIn(ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session)
+            mock_unlock_view_class.assert_not_called()
+
+    def test_process_request_new_away_auto_lock_version_without_password_does_not_lock(self):
+        """Test middleware records event version but does not lock when no password exists."""
+        request = self.factory.get('/console/entity/video-stream/1')
+        request.session = {}
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleSettingsHelper.get_console_lock_password') as mock_get_lock_password, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+            mock_get_lock_password.return_value = ''
+
+            response = self.middleware.process_request(request)
+
+            self.assertIsNone(response)
+            self.assertEqual(
+                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                '2',
+            )
+            self.assertNotIn(ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session)
+            mock_unlock_view_class.assert_not_called()
+
+    def test_process_request_api_status_when_locked_is_excluded(self):
+        """Test locked session does not block api_status path, which must stay pollable."""
+        request = self.factory.get(reverse('api_status'))
+        request.session = {
+            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
+        }
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
+
+            response = self.middleware.process_request(request)
+
+            self.assertIsNone(response)
+            self.assertEqual(
+                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                '3',
+            )
+            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
             mock_unlock_view_class.assert_not_called()

--- a/src/hi/apps/console/tests/test_console_lock_middleware.py
+++ b/src/hi/apps/console/tests/test_console_lock_middleware.py
@@ -1,0 +1,100 @@
+import logging
+from unittest.mock import Mock, patch
+
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.urls import reverse
+
+from hi.apps.console.constants import ConsoleConstants
+from hi.apps.console.middleware import ConsoleLockMiddleware
+from hi.testing.base_test_case import BaseTestCase
+
+logging.disable(logging.CRITICAL)
+
+
+class TestConsoleLockMiddleware(BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.get_response = Mock(return_value=HttpResponse('ok'))
+        self.middleware = ConsoleLockMiddleware(self.get_response)
+
+    def test_process_request_new_away_auto_lock_version_locks_console(self):
+        """Test middleware auto-locks when a new AWAY auto-lock event is seen."""
+        request = self.factory.get('/console/entity/video-stream/1')
+        request.session = {}
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+
+            mock_unlock_view = Mock()
+            mock_unlock_response = HttpResponse('locked', status=403)
+            mock_unlock_view.get.return_value = mock_unlock_response
+            mock_unlock_view_class.return_value = mock_unlock_view
+
+            response = self.middleware.process_request(request)
+
+            self.assertEqual(
+                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                '2',
+            )
+            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
+            mock_unlock_view.get.assert_called_once_with(request)
+            self.assertEqual(response, mock_unlock_response)
+
+    def test_process_request_same_auto_lock_version_does_not_relock(self):
+        """Test middleware does not relock when the AWAY auto-lock event was already seen."""
+        request = self.factory.get('/console/entity/video-stream/1')
+        request.session = {
+            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: False,
+        }
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+
+            response = self.middleware.process_request(request)
+
+            self.assertIsNone(response)
+            self.assertFalse(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
+            mock_unlock_view_class.assert_not_called()
+
+    def test_process_request_already_locked_marks_new_version_but_respects_unlock_path(self):
+        """Test middleware records new event version while allowing excluded unlock path."""
+        request = self.factory.get(reverse('console_unlock'))
+        request.session = {
+            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
+        }
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
+
+            response = self.middleware.process_request(request)
+
+            self.assertIsNone(response)
+            self.assertEqual(
+                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                '3',
+            )
+            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
+            mock_unlock_view_class.assert_not_called()
+
+    def test_process_request_without_auto_lock_version_does_nothing(self):
+        """Test middleware leaves lock state unchanged when there is no AWAY auto-lock event."""
+        request = self.factory.get('/console/entity/video-stream/1')
+        request.session = {}
+
+        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
+             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = None
+
+            response = self.middleware.process_request(request)
+
+            self.assertIsNone(response)
+            self.assertNotIn(ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session)
+            mock_unlock_view_class.assert_not_called()

--- a/src/hi/apps/console/tests/test_console_lock_middleware.py
+++ b/src/hi/apps/console/tests/test_console_lock_middleware.py
@@ -9,137 +9,129 @@ from hi.apps.console.constants import ConsoleConstants
 from hi.apps.console.middleware import ConsoleLockMiddleware
 from hi.testing.base_test_case import BaseTestCase
 
-logging.disable(logging.CRITICAL)
+logging.disable( logging.CRITICAL )
 
 
-class TestConsoleLockMiddleware(BaseTestCase):
+class TestConsoleLockMiddleware( BaseTestCase ):
 
-    def setUp(self):
+    def setUp( self ):
         super().setUp()
         self.factory = RequestFactory()
-        self.get_response = Mock(return_value=HttpResponse('ok'))
-        self.middleware = ConsoleLockMiddleware(self.get_response)
+        self.get_response = Mock( return_value = HttpResponse( 'ok' ) )
+        self.middleware = ConsoleLockMiddleware( self.get_response )
+        return
 
-    def test_process_request_new_away_auto_lock_version_locks_console(self):
-        """Test middleware auto-locks when a new AWAY auto-lock event is seen."""
-        request = self.factory.get('/console/entity/video-stream/1')
+    def test_new_away_auto_lock_version_locks_console( self ):
+        """Middleware auto-locks when a new AWAY auto-lock event is seen."""
+        request = self.factory.get( reverse( 'home' ) )
         request.session = {}
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleSettingsHelper.get_console_lock_password') as mock_get_lock_password, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager, \
+             patch( 'hi.apps.console.middleware.ConsoleSettingsHelper' ) as mock_helper, \
+             patch( 'hi.apps.console.middleware.ConsoleUnlockView' ) as mock_unlock_view:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
-            mock_get_lock_password.return_value = 'secret'
+            mock_helper.return_value.get_console_lock_password.return_value = 'secret'
+            mock_unlock_view.return_value.get.return_value = HttpResponse( 'locked', status = 403 )
 
-            mock_unlock_view = Mock()
-            mock_unlock_response = HttpResponse('locked', status=403)
-            mock_unlock_view.get.return_value = mock_unlock_response
-            mock_unlock_view_class.return_value = mock_unlock_view
-
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
             self.assertEqual(
                 request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
                 '2',
             )
-            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
-            mock_unlock_view.get.assert_called_once_with(request)
-            self.assertEqual(response, mock_unlock_response)
+            self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
+            self.assertIsNotNone( response )
+        return
 
-    def test_process_request_same_auto_lock_version_does_not_relock(self):
-        """Test middleware does not relock when the AWAY auto-lock event was already seen."""
-        request = self.factory.get('/console/entity/video-stream/1')
+    def test_same_auto_lock_version_does_not_relock( self ):
+        """Middleware does not relock when the AWAY auto-lock event was already seen."""
+        request = self.factory.get( reverse( 'home' ) )
         request.session = {
             ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: False,
         }
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
 
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
-            self.assertIsNone(response)
-            self.assertFalse(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
-            mock_unlock_view_class.assert_not_called()
+            self.assertIsNone( response )
+            self.assertFalse( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
+        return
 
-    def test_process_request_already_locked_marks_new_version_but_respects_unlock_path(self):
-        """Test middleware records new event version while allowing excluded unlock path."""
-        request = self.factory.get(reverse('console_unlock'))
+    def test_already_locked_records_version_and_respects_unlock_path( self ):
+        """Middleware records new event version while allowing excluded unlock path."""
+        request = self.factory.get( reverse( 'console_unlock' ) )
         request.session = {
             ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
         }
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
 
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
-            self.assertIsNone(response)
+            self.assertIsNone( response )
             self.assertEqual(
                 request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
                 '3',
             )
-            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
-            mock_unlock_view_class.assert_not_called()
+            self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
+        return
 
-    def test_process_request_without_auto_lock_version_does_nothing(self):
-        """Test middleware leaves lock state unchanged when there is no AWAY auto-lock event."""
-        request = self.factory.get('/console/entity/video-stream/1')
+    def test_no_auto_lock_version_does_nothing( self ):
+        """Middleware leaves lock state unchanged when there is no AWAY auto-lock event."""
+        request = self.factory.get( reverse( 'home' ) )
         request.session = {}
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = None
 
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
-            self.assertIsNone(response)
-            self.assertNotIn(ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session)
-            mock_unlock_view_class.assert_not_called()
+            self.assertIsNone( response )
+            self.assertNotIn( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session )
+        return
 
-    def test_process_request_new_away_auto_lock_version_without_password_does_not_lock(self):
-        """Test middleware records event version but does not lock when no password exists."""
-        request = self.factory.get('/console/entity/video-stream/1')
+    def test_new_auto_lock_version_without_password_does_not_lock( self ):
+        """Middleware records event version but does not lock when no password exists."""
+        request = self.factory.get( reverse( 'home' ) )
         request.session = {}
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleSettingsHelper.get_console_lock_password') as mock_get_lock_password, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager, \
+             patch( 'hi.apps.console.middleware.ConsoleSettingsHelper' ) as mock_helper:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
-            mock_get_lock_password.return_value = ''
+            mock_helper.return_value.get_console_lock_password.return_value = ''
 
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
-            self.assertIsNone(response)
+            self.assertIsNone( response )
             self.assertEqual(
                 request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
                 '2',
             )
-            self.assertNotIn(ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session)
-            mock_unlock_view_class.assert_not_called()
+            self.assertNotIn( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session )
+        return
 
-    def test_process_request_api_status_when_locked_is_excluded(self):
-        """Test locked session does not block api_status path, which must stay pollable."""
-        request = self.factory.get(reverse('api_status'))
+    def test_api_status_excluded_when_locked( self ):
+        """Locked session does not block api_status path, which must stay pollable."""
+        request = self.factory.get( reverse( 'api_status' ) )
         request.session = {
             ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
         }
 
-        with patch('hi.apps.console.middleware.SecurityManager') as mock_security_manager, \
-             patch('hi.apps.console.middleware.ConsoleUnlockView') as mock_unlock_view_class:
+        with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
             mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
 
-            response = self.middleware.process_request(request)
+            response = self.middleware.process_request( request )
 
-            self.assertIsNone(response)
+            self.assertIsNone( response )
             self.assertEqual(
                 request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
                 '3',
             )
-            self.assertTrue(request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR])
-            mock_unlock_view_class.assert_not_called()
+            self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
+        return

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -71,6 +71,8 @@ class SecurityManager( Singleton, SettingsMixin ):
         return self._security_level
 
     def get_console_away_auto_lock_version(self) -> str:
+        if not self._redis_client:
+            return None
         return self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
     
     def get_security_status_data(self) -> SecurityStatusData:
@@ -210,6 +212,8 @@ class SecurityManager( Singleton, SettingsMixin ):
         return
 
     def _increment_console_away_auto_lock_version(self):
+        if not self._redis_client:
+            return
         current_version_str = self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
         try:
             current_version = int(current_version_str)

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -1,6 +1,6 @@
 import logging
 from threading import Timer, Lock
-from typing import Dict
+from typing import Dict, Optional
 
 from django.core.exceptions import BadRequest
 from django.http import HttpRequest
@@ -70,10 +70,10 @@ class SecurityManager( Singleton, SettingsMixin ):
     def security_level(self) -> SecurityLevel:
         return self._security_level
 
-    def get_console_away_auto_lock_version(self) -> str:
+    def get_console_away_auto_lock_version( self ) -> Optional[str]:
         if not self._redis_client:
             return None
-        return self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
+        return self._redis_client.get( self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY )
     
     def get_security_status_data(self) -> SecurityStatusData:
         with self._security_status_lock:
@@ -211,19 +211,10 @@ class SecurityManager( Singleton, SettingsMixin ):
             self._increment_console_away_auto_lock_version()
         return
 
-    def _increment_console_away_auto_lock_version(self):
+    def _increment_console_away_auto_lock_version( self ) -> None:
         if not self._redis_client:
             return
-        current_version_str = self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
-        try:
-            current_version = int(current_version_str)
-        except (TypeError, ValueError):
-            current_version = 0
-
-        self._redis_client.set(
-            self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
-            str(current_version + 1),
-        )
+        self._redis_client.incr( self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY )
         return
     
     def update_security_state_auto( self, new_security_state  : SecurityState ):

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -29,6 +29,7 @@ class SecurityManager( Singleton, SettingsMixin ):
     SECURITY_STATE_LABEL_SNOOZED = 'Snoozed'
 
     SECURITY_STATE_CACHE_KEY = 'hi.security.state'
+    CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY = 'hi.console.away.auto_lock_version'
     
     def __init_singleton__(self):
         self._security_state = SecurityState.default()
@@ -68,6 +69,9 @@ class SecurityManager( Singleton, SettingsMixin ):
     @property
     def security_level(self) -> SecurityLevel:
         return self._security_level
+
+    def get_console_away_auto_lock_version(self) -> str:
+        return self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
     
     def get_security_status_data(self) -> SecurityStatusData:
         with self._security_status_lock:
@@ -199,7 +203,27 @@ class SecurityManager( Singleton, SettingsMixin ):
 
     def _apply_delayed_state( self ):
         logger.debug( f'Applying delayed security state = {self._delayed_security_state}' )
-        self.update_security_state_immediate( new_security_state = self._delayed_security_state )
+        delayed_security_state = self._delayed_security_state
+        self.update_security_state_immediate( new_security_state = delayed_security_state )
+        if delayed_security_state == SecurityState.AWAY:
+            self._increment_console_away_auto_lock_version_if_enabled()
+        return
+
+    def _increment_console_away_auto_lock_version_if_enabled(self):
+        lock_password = ConsoleSettingsHelper().get_console_lock_password()
+        if not lock_password:
+            return
+
+        current_version_str = self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
+        try:
+            current_version = int(current_version_str)
+        except (TypeError, ValueError):
+            current_version = 0
+
+        self._redis_client.set(
+            self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
+            str(current_version + 1),
+        )
         return
     
     def update_security_state_auto( self, new_security_state  : SecurityState ):

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -206,14 +206,10 @@ class SecurityManager( Singleton, SettingsMixin ):
         delayed_security_state = self._delayed_security_state
         self.update_security_state_immediate( new_security_state = delayed_security_state )
         if delayed_security_state == SecurityState.AWAY:
-            self._increment_console_away_auto_lock_version_if_enabled()
+            self._increment_console_away_auto_lock_version()
         return
 
-    def _increment_console_away_auto_lock_version_if_enabled(self):
-        lock_password = ConsoleSettingsHelper().get_console_lock_password()
-        if not lock_password:
-            return
-
+    def _increment_console_away_auto_lock_version(self):
         current_version_str = self._redis_client.get(self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY)
         try:
             current_version = int(current_version_str)

--- a/src/hi/apps/security/tests/test_security_manager.py
+++ b/src/hi/apps/security/tests/test_security_manager.py
@@ -277,6 +277,38 @@ class TestSecurityManager(BaseTestCase):
             
             mock_update.assert_called_once_with(new_security_state=SecurityState.AWAY)
 
+    def test_apply_delayed_state_away_with_lock_password_triggers_auto_lock_event(self):
+        """Test delayed AWAY transition increments console auto-lock event version."""
+        manager = SecurityManager()
+        manager._delayed_security_state = SecurityState.AWAY
+        manager._redis_client = Mock()
+        manager._redis_client.get.return_value = '7'
+
+        with patch('hi.apps.security.security_manager.ConsoleSettingsHelper.get_console_lock_password') as mock_password:
+            mock_password.return_value = 'secret'
+
+            with patch.object(manager, 'update_security_state_immediate'):
+                manager._apply_delayed_state()
+
+        manager._redis_client.set.assert_called_once_with(
+            SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
+            '8',
+        )
+
+    def test_apply_delayed_state_away_without_lock_password_does_not_trigger_auto_lock_event(self):
+        """Test delayed AWAY transition does not auto-lock when no lock password is configured."""
+        manager = SecurityManager()
+        manager._delayed_security_state = SecurityState.AWAY
+        manager._redis_client = Mock()
+
+        with patch('hi.apps.security.security_manager.ConsoleSettingsHelper.get_console_lock_password') as mock_password:
+            mock_password.return_value = ''
+
+            with patch.object(manager, 'update_security_state_immediate'):
+                manager._apply_delayed_state()
+
+        manager._redis_client.set.assert_not_called()
+
     def test_update_security_state_auto_blocked_by_state(self):
         """Test auto update blocked by non-auto-changeable state."""
         manager = SecurityManager()

--- a/src/hi/apps/security/tests/test_security_manager.py
+++ b/src/hi/apps/security/tests/test_security_manager.py
@@ -271,10 +271,11 @@ class TestSecurityManager(BaseTestCase):
         """Test apply delayed state - calls immediate update with delayed state."""
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.AWAY
-        
+        manager._redis_client = Mock()
+
         with patch.object(manager, 'update_security_state_immediate') as mock_update:
             manager._apply_delayed_state()
-            
+
             mock_update.assert_called_once_with(new_security_state=SecurityState.AWAY)
 
     def test_apply_delayed_state_away_triggers_auto_lock_event(self):
@@ -282,30 +283,26 @@ class TestSecurityManager(BaseTestCase):
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.AWAY
         manager._redis_client = Mock()
-        manager._redis_client.get.return_value = '7'
 
-        with patch.object(manager, 'update_security_state_immediate'):
+        with patch.object( manager, 'update_security_state_immediate' ):
             manager._apply_delayed_state()
 
-        manager._redis_client.set.assert_called_once_with(
+        manager._redis_client.incr.assert_called_once_with(
             SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
-            '8',
         )
+        return
 
-    def test_apply_delayed_state_away_initializes_auto_lock_event_version_when_unset(self):
-        """Test delayed AWAY transition initializes auto-lock event version when missing."""
+    def test_apply_delayed_state_non_away_does_not_trigger_auto_lock(self):
+        """Test delayed non-AWAY transition does not increment auto-lock version."""
         manager = SecurityManager()
-        manager._delayed_security_state = SecurityState.AWAY
+        manager._delayed_security_state = SecurityState.NIGHT
         manager._redis_client = Mock()
-        manager._redis_client.get.return_value = None
 
-        with patch.object(manager, 'update_security_state_immediate'):
+        with patch.object( manager, 'update_security_state_immediate' ):
             manager._apply_delayed_state()
 
-        manager._redis_client.set.assert_called_once_with(
-            SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
-            '1',
-        )
+        manager._redis_client.incr.assert_not_called()
+        return
 
     def test_update_security_state_auto_blocked_by_state(self):
         """Test auto update blocked by non-auto-changeable state."""

--- a/src/hi/apps/security/tests/test_security_manager.py
+++ b/src/hi/apps/security/tests/test_security_manager.py
@@ -277,37 +277,35 @@ class TestSecurityManager(BaseTestCase):
             
             mock_update.assert_called_once_with(new_security_state=SecurityState.AWAY)
 
-    def test_apply_delayed_state_away_with_lock_password_triggers_auto_lock_event(self):
+    def test_apply_delayed_state_away_triggers_auto_lock_event(self):
         """Test delayed AWAY transition increments console auto-lock event version."""
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.AWAY
         manager._redis_client = Mock()
         manager._redis_client.get.return_value = '7'
 
-        with patch('hi.apps.security.security_manager.ConsoleSettingsHelper.get_console_lock_password') as mock_password:
-            mock_password.return_value = 'secret'
-
-            with patch.object(manager, 'update_security_state_immediate'):
-                manager._apply_delayed_state()
+        with patch.object(manager, 'update_security_state_immediate'):
+            manager._apply_delayed_state()
 
         manager._redis_client.set.assert_called_once_with(
             SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
             '8',
         )
 
-    def test_apply_delayed_state_away_without_lock_password_does_not_trigger_auto_lock_event(self):
-        """Test delayed AWAY transition does not auto-lock when no lock password is configured."""
+    def test_apply_delayed_state_away_initializes_auto_lock_event_version_when_unset(self):
+        """Test delayed AWAY transition initializes auto-lock event version when missing."""
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.AWAY
         manager._redis_client = Mock()
+        manager._redis_client.get.return_value = None
 
-        with patch('hi.apps.security.security_manager.ConsoleSettingsHelper.get_console_lock_password') as mock_password:
-            mock_password.return_value = ''
+        with patch.object(manager, 'update_security_state_immediate'):
+            manager._apply_delayed_state()
 
-            with patch.object(manager, 'update_security_state_immediate'):
-                manager._apply_delayed_state()
-
-        manager._redis_client.set.assert_not_called()
+        manager._redis_client.set.assert_called_once_with(
+            SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
+            '1',
+        )
 
     def test_update_security_state_auto_blocked_by_state(self):
         """Test auto update blocked by non-auto-changeable state."""

--- a/src/hi/static/js/status.js
+++ b/src/hi/static/js/status.js
@@ -33,6 +33,8 @@
     const CssClassUpdateMapAttr = 'cssClassUpdateMap';
     const IdReplaceUpdateMapAttr = 'idReplaceUpdateMap';
     const IdReplaceHashMapAttr = 'idReplaceHashMap';
+    const ConsoleLockedAttr = 'consoleLocked';
+    const ConsoleUnlockUrl = '/console/unlock';
     const TransientViewSuggestionAttr = 'transientViewSuggestion';
     const TransientViewUrlAttr = 'url';
     const TransientViewDurationSecondsAttr = 'durationSeconds';
@@ -128,6 +130,10 @@
         if ( Hi.DEBUG && TRACE ) { console.log( "Server response: "+JSON.stringify( respObj)); }
 
         doServerStartTimeCheck( respObj );
+
+        if ( ConsoleLockedAttr in respObj ) {
+            handleConsoleLockState( respObj[ConsoleLockedAttr] );
+        }
         
         if ( ServerTimestampAttr in respObj ) {
             gLastServerDate = new Date( respObj[ServerTimestampAttr] );
@@ -144,6 +150,22 @@
         }
         if ( TransientViewSuggestionAttr in respObj ) {
             handleTransientViewSuggestion( respObj[TransientViewSuggestionAttr] );
+        }
+    }
+
+    function handleConsoleLockState( isConsoleLocked ) {
+        if ( ! isConsoleLocked ) {
+            return;
+        }
+
+        // Avoid creating a duplicate unlock modal while one is already visible.
+        const unlockModalVisible = $('form[action="' + ConsoleUnlockUrl + '"]').closest('.modal.show').length > 0;
+        if ( unlockModalVisible ) {
+            return;
+        }
+
+        if ( window.AN && window.AN.get ) {
+            window.AN.get( ConsoleUnlockUrl );
         }
     }
 


### PR DESCRIPTION
## Pull Request: Auto-Lock Console On Delayed AWAY

### Issue Link

Closes #220 

---

## Category

- [x] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [x] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Added delayed-AWAY auto-lock event signaling in the security flow by incrementing a Redis-backed version when AWAY takes effect after delay.
- Added middleware handling to consume AWAY auto-lock events once per session and lock the console only when a lock password is configured.
- Updated existing tests for AWAY auto-lock behavior in security and console middleware, including no-password and excluded-path cases.

---

## How to Test

1. Configure a console lock password in settings.
2. Configure a non-zero AWAY delay and switch security mode to AWAY.
3. Wait until the delay completes and confirm the console auto-locks.
4. Unlock with the configured password and confirm access is restored.
5. Remove/clear lock password, trigger delayed AWAY again, and confirm auto-lock does not occur.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra