### PR TITLE
Establish shared URL constants between server and client (Issue #268)

### DIFF
--- a/src/hi/environment/client.py
+++ b/src/hi/environment/client.py
@@ -11,12 +11,14 @@ class ClientConfig:
     needed.
 
     """
-    DEBUG         : bool
-    ENVIRONMENT   : str
-    VERSION       : str
-    VIEW_MODE     : str
-    VIEW_TYPE     : str
-    IS_EDIT_MODE  : bool
+    DEBUG              : bool
+    ENVIRONMENT        : str
+    VERSION            : str
+    VIEW_MODE          : str
+    VIEW_TYPE          : str
+    IS_EDIT_MODE       : bool
+    API_STATUS_URL     : str = ''
+    CONSOLE_UNLOCK_URL : str = ''
     
     def to_json_dict(self) -> dict:
         """

--- a/src/hi/environment/context_processors.py
+++ b/src/hi/environment/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 
 from .client import ClientConfig
 
@@ -23,6 +24,8 @@ def client_config(request):
         VIEW_MODE = str(request.view_parameters.view_mode),
         VIEW_TYPE = str(request.view_parameters.view_type) if request.view_parameters.view_type else None,
         IS_EDIT_MODE = request.view_parameters.is_editing,
+        API_STATUS_URL = reverse( 'api_status' ),
+        CONSOLE_UNLOCK_URL = reverse( 'console_unlock' ),
     )
     
     return {

--- a/src/hi/static/js/main.js
+++ b/src/hi/static/js/main.js
@@ -12,6 +12,10 @@
         DEBUG: window.HiClientConfig?.DEBUG ?? false,
         isEditMode: window.HiClientConfig?.IS_EDIT_MODE ?? false,
 
+        // Server-provided URLs (via ClientConfig context processor)
+        API_STATUS_URL: window.HiClientConfig?.API_STATUS_URL ?? '/api/status',
+        CONSOLE_UNLOCK_URL: window.HiClientConfig?.CONSOLE_UNLOCK_URL ?? '/console/unlock',
+
         MAIN_AREA_SELECTOR: '#hi-main-content',
         LOCATION_VIEW_AREA_SELECTOR: '#hi-location-view-main',
         LOCATION_VIEW_SVG_CLASS: 'hi-location-view-svg',

--- a/src/hi/static/js/status.js
+++ b/src/hi/static/js/status.js
@@ -26,7 +26,7 @@
     const ServerPollingIntervalMs = 3 * 1000;
     const PollingErrorNotifyTimeMs = 60 * 1000;
     const ServerErrorMessageSelector = '#hi-server-error-msg';
-    const ServerPollingUrl = '/api/status';
+    const ServerPollingUrl = Hi.API_STATUS_URL;
     const ServerStartTimestampAttr = 'startTimestamp';
     const ServerTimestampAttr = 'timestamp';
     const LastServerTimestampAttr = 'lastTimestamp';
@@ -34,7 +34,7 @@
     const IdReplaceUpdateMapAttr = 'idReplaceUpdateMap';
     const IdReplaceHashMapAttr = 'idReplaceHashMap';
     const ConsoleLockedAttr = 'consoleLocked';
-    const ConsoleUnlockUrl = '/console/unlock';
+    const ConsoleUnlockUrl = Hi.CONSOLE_UNLOCK_URL;
     const TransientViewSuggestionAttr = 'transientViewSuggestion';
     const TransientViewUrlAttr = 'url';
     const TransientViewDurationSecondsAttr = 'durationSeconds';


### PR DESCRIPTION
## Pull Request: Establish shared URL constants between server and client

### Issue Link
Closes #268

---

## Category
- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [x] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Replace hardcoded URL path strings in JavaScript with server-provided constants using Django's `reverse()`.

- Add `API_STATUS_URL` and `CONSOLE_UNLOCK_URL` fields to `ClientConfig` dataclass
- Populate via `reverse()` in the context processor (single source of truth from Django URL routing)
- Expose through `Hi` namespace in `main.js` with fallback defaults for JS-only test environments
- Replace hardcoded `/api/status` and `/console/unlock` strings in `status.js`

This establishes a reusable pattern: URLs defined in Django routing → resolved via `reverse()` → serialized to `HiClientConfig` → consumed by JS through `Hi.*`.

---

## How to Test
1. Run the app and verify status polling works (check browser network tab for `/api/status` calls)
2. Verify console lock/unlock still works (set security to AWAY with a lock password configured)
3. `make test` — all 2185 tests pass
4. `make lint` — clean

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs
- PR #266 (AWAY mode auto-lock) — identified the hardcoded URL issue

---

## Screenshots (if applicable)

---

## Additional Notes
- Fallback defaults in main.js (`?? '/api/status'`) ensure backward compatibility if `HiClientConfig` is not available (e.g., JS unit test environments)
- Future URLs can follow the same pattern: add field to `ClientConfig`, populate in context processor, expose in `Hi` namespace

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
