### PR TITLE
Replace AWAY auto-lock version counter with timestamp

### DIFF
--- a/src/hi/apps/console/constants.py
+++ b/src/hi/apps/console/constants.py
@@ -1,5 +1,5 @@
 class ConsoleConstants:
 
     CONSOLE_LOCKED_SESSION_VAR = 'console_locked'
-    CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR = 'console_away_auto_lock_version'
+    CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR = 'console_away_lock_timestamp'
     DATETIME_HEADER_TEMPLATE_NAME = 'console/panes/datetime_header.html'

--- a/src/hi/apps/console/middleware.py
+++ b/src/hi/apps/console/middleware.py
@@ -36,17 +36,17 @@ class ConsoleLockMiddleware:
         return None
 
     def _process_away_auto_lock( self, request : HttpRequest ) -> None:
-        auto_lock_version = SecurityManager().get_console_away_auto_lock_version()
-        if not auto_lock_version:
+        away_timestamp = SecurityManager().get_console_away_lock_timestamp()
+        if not away_timestamp:
             return
 
-        previous_auto_lock_version = request.session.get(
-            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR
+        previous_away_timestamp = request.session.get(
+            ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR
         )
-        if str( previous_auto_lock_version ) == str( auto_lock_version ):
+        if str( previous_away_timestamp ) == str( away_timestamp ):
             return
 
-        request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR] = str( auto_lock_version )
+        request.session[ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR] = str( away_timestamp )
 
         if request.session.get( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, False ):
             return

--- a/src/hi/apps/console/tests/test_console_lock_middleware.py
+++ b/src/hi/apps/console/tests/test_console_lock_middleware.py
@@ -29,14 +29,14 @@ class TestConsoleLockMiddleware( BaseTestCase ):
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager, \
              patch( 'hi.apps.console.middleware.ConsoleSettingsHelper' ) as mock_helper, \
              patch( 'hi.apps.console.middleware.ConsoleUnlockView' ) as mock_unlock_view:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = '2'
             mock_helper.return_value.get_console_lock_password.return_value = 'secret'
             mock_unlock_view.return_value.get.return_value = HttpResponse( 'locked', status = 403 )
 
             response = self.middleware.process_request( request )
 
             self.assertEqual(
-                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                request.session[ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR],
                 '2',
             )
             self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
@@ -47,12 +47,12 @@ class TestConsoleLockMiddleware( BaseTestCase ):
         """Middleware does not relock when the AWAY auto-lock event was already seen."""
         request = self.factory.get( reverse( 'home' ) )
         request.session = {
-            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: False,
         }
 
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = '2'
 
             response = self.middleware.process_request( request )
 
@@ -64,18 +64,18 @@ class TestConsoleLockMiddleware( BaseTestCase ):
         """Middleware records new event version while allowing excluded unlock path."""
         request = self.factory.get( reverse( 'console_unlock' ) )
         request.session = {
-            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
         }
 
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = '3'
 
             response = self.middleware.process_request( request )
 
             self.assertIsNone( response )
             self.assertEqual(
-                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                request.session[ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR],
                 '3',
             )
             self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )
@@ -87,7 +87,7 @@ class TestConsoleLockMiddleware( BaseTestCase ):
         request.session = {}
 
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = None
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = None
 
             response = self.middleware.process_request( request )
 
@@ -102,14 +102,14 @@ class TestConsoleLockMiddleware( BaseTestCase ):
 
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager, \
              patch( 'hi.apps.console.middleware.ConsoleSettingsHelper' ) as mock_helper:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '2'
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = '2'
             mock_helper.return_value.get_console_lock_password.return_value = ''
 
             response = self.middleware.process_request( request )
 
             self.assertIsNone( response )
             self.assertEqual(
-                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                request.session[ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR],
                 '2',
             )
             self.assertNotIn( ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR, request.session )
@@ -119,18 +119,18 @@ class TestConsoleLockMiddleware( BaseTestCase ):
         """Locked session does not block api_status path, which must stay pollable."""
         request = self.factory.get( reverse( 'api_status' ) )
         request.session = {
-            ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR: '2',
+            ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR: '2',
             ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR: True,
         }
 
         with patch( 'hi.apps.console.middleware.SecurityManager' ) as mock_security_manager:
-            mock_security_manager.return_value.get_console_away_auto_lock_version.return_value = '3'
+            mock_security_manager.return_value.get_console_away_lock_timestamp.return_value = '3'
 
             response = self.middleware.process_request( request )
 
             self.assertIsNone( response )
             self.assertEqual(
-                request.session[ConsoleConstants.CONSOLE_AWAY_AUTO_LOCK_VERSION_SESSION_VAR],
+                request.session[ConsoleConstants.CONSOLE_AWAY_LOCK_TIMESTAMP_SESSION_VAR],
                 '3',
             )
             self.assertTrue( request.session[ConsoleConstants.CONSOLE_LOCKED_SESSION_VAR] )

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -29,7 +29,7 @@ class SecurityManager( Singleton, SettingsMixin ):
     SECURITY_STATE_LABEL_SNOOZED = 'Snoozed'
 
     SECURITY_STATE_CACHE_KEY = 'hi.security.state'
-    CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY = 'hi.console.away.auto_lock_version'
+    CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY = 'hi.console.away.lock_timestamp'
     
     def __init_singleton__(self):
         self._security_state = SecurityState.default()
@@ -70,10 +70,10 @@ class SecurityManager( Singleton, SettingsMixin ):
     def security_level(self) -> SecurityLevel:
         return self._security_level
 
-    def get_console_away_auto_lock_version( self ) -> Optional[str]:
+    def get_console_away_lock_timestamp( self ) -> Optional[str]:
         if not self._redis_client:
             return None
-        return self._redis_client.get( self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY )
+        return self._redis_client.get( self.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY )
     
     def get_security_status_data(self) -> SecurityStatusData:
         with self._security_status_lock:
@@ -208,13 +208,22 @@ class SecurityManager( Singleton, SettingsMixin ):
         delayed_security_state = self._delayed_security_state
         self.update_security_state_immediate( new_security_state = delayed_security_state )
         if delayed_security_state == SecurityState.AWAY:
-            self._increment_console_away_auto_lock_version()
+            self._set_console_away_lock_timestamp()
         return
 
-    def _increment_console_away_auto_lock_version( self ) -> None:
+    def _set_console_away_lock_timestamp( self ) -> None:
         if not self._redis_client:
             return
-        self._redis_client.incr( self.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY )
+        self._redis_client.set(
+            self.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY,
+            str( datetimeproxy.now() ),
+        )
+        return
+
+    def _delete_console_away_lock_timestamp( self ) -> None:
+        if not self._redis_client:
+            return
+        self._redis_client.delete( self.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY )
         return
     
     def update_security_state_auto( self, new_security_state  : SecurityState ):
@@ -260,7 +269,7 @@ class SecurityManager( Singleton, SettingsMixin ):
             self._security_status_lock.acquire()
         try:
             self._cancel_security_state_transition()
-            
+
             if new_security_state == SecurityState.DISABLED:
                 self._security_level = SecurityLevel.OFF
 
@@ -276,9 +285,13 @@ class SecurityManager( Singleton, SettingsMixin ):
                 logger.error( f'Unsupported security state "{new_security_state}"' )
                 return
 
+            previous_state = self._security_state
             self._security_state = new_security_state
             self._redis_client.set( self.SECURITY_STATE_CACHE_KEY, str( self._security_state ))
-            
+
+            if previous_state == SecurityState.AWAY and new_security_state != SecurityState.AWAY:
+                self._delete_console_away_lock_timestamp()
+
         finally:
             if not lock_acquired:
                 self._security_status_lock.release()
@@ -299,6 +312,8 @@ class SecurityManager( Singleton, SettingsMixin ):
             previous_security_state = SecurityState.from_name_safe( previous_security_state_str )
             if not previous_security_state.auto_change_allowed:
                 self.update_security_state_immediate( new_security_state = previous_security_state )
+                if previous_security_state == SecurityState.AWAY:
+                    self._set_console_away_lock_timestamp()
                 return
         
         # Else, revert to look at time of day to initialize the state.

--- a/src/hi/apps/security/tests/test_security_manager.py
+++ b/src/hi/apps/security/tests/test_security_manager.py
@@ -278,8 +278,8 @@ class TestSecurityManager(BaseTestCase):
 
             mock_update.assert_called_once_with(new_security_state=SecurityState.AWAY)
 
-    def test_apply_delayed_state_away_triggers_auto_lock_event(self):
-        """Test delayed AWAY transition increments console auto-lock event version."""
+    def test_apply_delayed_state_away_sets_lock_timestamp(self):
+        """Test delayed AWAY transition sets console auto-lock timestamp."""
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.AWAY
         manager._redis_client = Mock()
@@ -287,13 +287,14 @@ class TestSecurityManager(BaseTestCase):
         with patch.object( manager, 'update_security_state_immediate' ):
             manager._apply_delayed_state()
 
-        manager._redis_client.incr.assert_called_once_with(
-            SecurityManager.CONSOLE_AWAY_AUTO_LOCK_VERSION_CACHE_KEY,
+        manager._redis_client.set.assert_called_once_with(
+            SecurityManager.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY,
+            manager._redis_client.set.call_args[0][1],  # timestamp string
         )
         return
 
-    def test_apply_delayed_state_non_away_does_not_trigger_auto_lock(self):
-        """Test delayed non-AWAY transition does not increment auto-lock version."""
+    def test_apply_delayed_state_non_away_does_not_set_timestamp(self):
+        """Test delayed non-AWAY transition does not set auto-lock timestamp."""
         manager = SecurityManager()
         manager._delayed_security_state = SecurityState.NIGHT
         manager._redis_client = Mock()
@@ -301,7 +302,61 @@ class TestSecurityManager(BaseTestCase):
         with patch.object( manager, 'update_security_state_immediate' ):
             manager._apply_delayed_state()
 
-        manager._redis_client.incr.assert_not_called()
+        manager._redis_client.set.assert_not_called()
+        return
+
+    def test_leaving_away_deletes_lock_timestamp(self):
+        """Test transitioning out of AWAY deletes the auto-lock timestamp."""
+        manager = SecurityManager()
+        manager._security_state = SecurityState.AWAY
+        manager._redis_client = Mock()
+
+        manager.update_security_state_immediate( SecurityState.DAY )
+
+        manager._redis_client.delete.assert_called_once_with(
+            SecurityManager.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY,
+        )
+        return
+
+    def test_staying_in_away_does_not_delete_timestamp(self):
+        """Test re-entering AWAY does not delete the auto-lock timestamp."""
+        manager = SecurityManager()
+        manager._security_state = SecurityState.AWAY
+        manager._redis_client = Mock()
+
+        manager.update_security_state_immediate( SecurityState.AWAY )
+
+        manager._redis_client.delete.assert_not_called()
+        return
+
+    def test_non_away_transition_does_not_delete_timestamp(self):
+        """Test non-AWAY to non-AWAY transition does not delete timestamp."""
+        manager = SecurityManager()
+        manager._security_state = SecurityState.DAY
+        manager._redis_client = Mock()
+
+        manager.update_security_state_immediate( SecurityState.NIGHT )
+
+        manager._redis_client.delete.assert_not_called()
+        return
+
+    @patch('hi.apps.security.security_manager.get_redis_client')
+    def test_initialize_away_sets_lock_timestamp(self, mock_get_redis_client):
+        """Test initializing with AWAY state sets a fresh lock timestamp."""
+        mock_redis = Mock()
+        mock_get_redis_client.return_value = mock_redis
+        mock_redis.get.return_value = str( SecurityState.AWAY )
+
+        manager = SecurityManager()
+        manager._initialize_security_state()
+
+        # Should set the lock timestamp (second set call after the state set)
+        set_calls = mock_redis.set.call_args_list
+        timestamp_calls = [
+            c for c in set_calls
+            if c[0][0] == SecurityManager.CONSOLE_AWAY_LOCK_TIMESTAMP_CACHE_KEY
+        ]
+        self.assertEqual( len( timestamp_calls ), 1 )
         return
 
     def test_update_security_state_auto_blocked_by_state(self):


### PR DESCRIPTION
## Pull Request: Replace AWAY auto-lock version counter with timestamp

### Issue Link

Closes #271

---

## Category

- [ ] **Feature** (New functionality)
- [x] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)

- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- Replaced Redis `INCR` version counter with `SET` timestamp for AWAY auto-lock tracking
- Timestamp is set on AWAY entry (`_set_console_away_lock_timestamp`) and deleted on AWAY exit (`_delete_console_away_lock_timestamp`), so the key is absent when AWAY is not active
- Fresh sessions correctly skip locking when AWAY is not active (Redis key absent → early return)
- Server restart during AWAY sets a fresh timestamp, ensuring all sessions re-lock
- Renamed constants: `CONSOLE_AWAY_AUTO_LOCK_VERSION_*` → `CONSOLE_AWAY_LOCK_TIMESTAMP_*`
- Added tests for timestamp deletion on AWAY exit, no-op on non-AWAY transitions, and timestamp set on initialization

---

## How to Test

1. Set AWAY → console locks on all sessions
2. Exit AWAY → console unlocks (per-session, each must enter password)
3. New browser tab during AWAY → locks
4. New browser tab after AWAY ends → no lock
5. Restart server during AWAY → fresh page load locks
6. `make test` — all 2189 tests pass

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
