### PR TITLE
Issue #280: Per-integration documentation structure and content

### DIFF
--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -2,35 +2,41 @@
 
 # Integrations
 
-We will add more integrations as there is demand, but presently the current supported integrations are:
-- **Home Assistant** - General home automation platform for many types of devices and protocols. Requires installation and setup.
-- **ZoneMinder** - For managing security cameras with motion detection. Requires installation and setup.
-- **HomeBox** - Home inventory management system for tracking household items, warranties, and documentation. Requires installation and setup.
+Home Information (HI) can optionally connect to external systems to
+import items from them — alongside your own items and items from any
+other integrations you enable. Integrations are not required; HI
+works without any of them. Each integration has its own setup steps,
+credentials, and caveats — see the per-integration page for details.
 
-To enable an integration, go to "Settings > Integrations > Add Integrations".
+You will need credentials for the upstream service before starting;
+the per-integration pages below cover what to obtain and where to
+enter it.
 
-When you enable one of these integrations, you will need to provide the necessary connection information, usually in the way of API endpoints and credentials. 
+## Enabling an integration
 
-## Home Assistant
+1. In HI, click **CONFIGURE** at the bottom of the screen.
+2. Select the **Integrations** tab.
+3. Open the integrations picker:
+   - If no integrations are configured yet, click **CONFIGURE
+     INTEGRATIONS** in the main panel.
+   - If at least one integration is already configured, click
+     **INTEGRATIONS** at the top of the sidebar.
+4. Choose the integration you want to add and follow the
+   configuration steps on its per-integration page below.
 
-You will need install and set this up by following all their documentation. Start at the [Home Assistant Home Page](https://www.home-assistant.io/).
+## Available integrations
 
-## ZoneMinder
+- **[Home Assistant](integrations/home-assistant.md)** — general-purpose
+  home automation platform. Imports HA entities (lights, switches,
+  sensors, cameras, climate devices, and more) and dispatches control
+  actions back to HA.
+- **[ZoneMinder](integrations/zoneminder.md)** — open-source video
+  surveillance. Imports ZM monitors as cameras with motion sensors and
+  function controllers; provides live stream playback in HI.
+- **[HomeBox](integrations/homebox.md)** — home inventory tracking.
+  Imports HomeBox items as read-only HI items with custom fields and
+  attached files (manuals, receipts, photos).
 
-You will need install and set this up by following all their documentation. Start at the [ZoneMinder Home Page](https://zoneminder.com//).
-
-## HomeBox
-
-You will need to install and set this up by following all their documentation. Start at the [HomeBox Home Page](https://homebox.software/). The API credentials are the same username and password you use to log into the HomeBox web interface.
-
-### CORS Issues
-
-If you are going to use the ZoneMinder integration, then viewing the camera video streams requires the server to authorize the browser to allow the ZoneMinder server to be an allowed off-site "origin".  You will need to add the ZoneMinder URL to an envirornment variable to have Django server up the right headers to the browser:
-``` shell
-export HI_EXTRA_CSP_URLS="${SCHEME}://${HOST}:${PORT}"
-```
-
-### HTTPS/SSL Issues
-
-Another potential issue with viewing the ZoneMinder camera streams can happen if your Home Information server runs trhrough HTTP and the ZoneMinder server streams are served thruogh HTTPS/SSL.  Browsers prevent that due to the security implications.  This can be made worse if the ZoneMinder server is using a self-signed SSL cert (the default?). A workaround we found was to stand up an nginx server to proxy the HTTPS/SSL urls and serve them as plain HTTP in Home Information pages by changing the ZoneMinder setting "Portal URL".
-
+More integrations will be added as demand arises. The per-integration
+pages each carry their own troubleshooting section that accretes
+real-world fixes over time — start there if something is not working.

--- a/docs/dev/integrations/_template.md
+++ b/docs/dev/integrations/_template.md
@@ -1,0 +1,60 @@
+<!--
+  TEMPLATE — copy this file to docs/dev/integrations/<integration-name>.md
+  and fill in each section.
+
+  Goal: orient a developer who has never read this integration's code
+  before. Keep it high-level and point at the code for details — the
+  code is the authoritative source. Do not duplicate class signatures,
+  method bodies, or field lists; the moment those drift, the doc
+  starts misleading. Refer to file paths and class names instead.
+-->
+
+# <Integration Name>
+
+## Overview
+
+One paragraph on the integration's architecture: what major pieces
+exist (gateway, manager, sync, monitors, client) and how they fit
+together. Mention how this integration's shape differs from the
+generic pattern in `integration-guidelines.md` if at all.
+
+## Key modules
+
+A short list of the most important files and classes a new
+contributor should know about, each with a one-line description of
+its role. Do not enumerate every file — pick the entry points.
+
+- `src/hi/services/<name>/<file>.py` — `<ClassName>`. <One-line role>.
+- `src/hi/services/<name>/<file>.py` — `<ClassName>`. <One-line role>.
+
+## API patterns
+
+Which external endpoints the integration depends on, the
+authentication model, and any rate-limiting or polling cadence
+considerations. State the shape; do not paste request/response bodies
+(those belong in test fixtures or upstream docs).
+
+## Implementation notes
+
+Non-obvious decisions, workarounds, and quirks of the upstream service
+that influenced the implementation. This is the section future-you
+will be most grateful for. Examples of what belongs here:
+
+- Why a specific endpoint is preferred over an obvious alternative.
+- Quirks in the upstream API (inconsistent field names, eventual
+  consistency windows, undocumented limits).
+- Tradeoffs taken in the converter (heuristics, fallbacks).
+
+## Testing approach
+
+Where tests live and the mocking patterns used. If there is simulator
+support for this integration, mention where (`src/hi/simulator/services/<name>/`)
+and what it covers. Manual testing notes belong in
+`docs/dev/testing/test-simulator.md`, not here.
+
+## References
+
+Links to upstream API documentation and any related internal docs.
+
+- Upstream: <link>
+- Related: <link to related internal doc, if any>

--- a/docs/dev/integrations/home-assistant.md
+++ b/docs/dev/integrations/home-assistant.md
@@ -1,20 +1,86 @@
-# Home Assistant (HA) Integration
+# Home Assistant
 
-Ths app uses the `module hi.services.hass` to integrate with the Home Assistant API. It uses the app's general integration framework defined in the module `hi.integrations`.
+## Overview
 
-## Initial Synchronization
+The Home Assistant integration follows the standard pattern in
+`integration-guidelines.md`: a `HassGateway` exposes the framework
+surface (manage view, monitor, controller, synchronizer); a singleton
+`HassManager` owns shared client state; `HassConverter` translates
+upstream HA states into HI items at import time; `HassMonitor` runs
+in the background to poll for state changes; and `HassController`
+dispatches HI control actions back to HA.
 
-When first enabled, it pulls in the state values via the API and does the following:
-- Attempts to combined states that are part of the same device.
-- Maps each HA state to our model's EntityState.
-- Maps each aggregated "device" into our model's EntityState.
-- For each state, create our models Sensor and/or Controller depending on the type of state.
+User-facing setup and troubleshooting live in
+[`docs/integrations/home-assistant.md`](../../integrations/home-assistant.md).
 
-After the initial synchronization, our database is populated with an IntegratiohnKey reference back to the HA state. This is done by `hi.services/hass.hass_sync.HassSynchronizer`.
+## Key modules
 
-The capabilities of the states/devices from HA are hard-coded in the `hi.services/hass.hass_converter.HassConverter` module.  This mapping is based solely on guessing based on the available information in the API response.  This is imperfect information and a lot of heuristics are used.
+- `src/hi/services/hass/integration.py` — `HassGateway`. Framework
+  entry point.
+- `src/hi/services/hass/hass_manager.py` — `HassManager`. Singleton
+  holding the active `HassClient` and the integration attribute map.
+- `src/hi/services/hass/hass_client.py` — `HassClient`. Thin REST
+  wrapper over HA's `/api/states` and `/api/services/...`. Built on
+  top of the standard `requests` library.
+- `src/hi/services/hass/hass_converter.py` — `HassConverter`.
+  Heuristic mapping of upstream HA states to HI items. The bulk of
+  integration-specific complexity lives here. Aggregates multi-state
+  HA devices into a single HI item where it can.
+- `src/hi/services/hass/hass_sync.py` — `HassSynchronizer`. Drives
+  the Import / Refresh flow; delegates to the converter for the
+  per-item shape.
+- `src/hi/services/hass/monitors.py` — `HassMonitor`. Periodic poll
+  against `/api/states`; produces `SensorResponse` events for state
+  changes.
+- `src/hi/services/hass/hass_controller.py` — `HassController`.
+  Translates HI control actions back into HA service calls.
 
-## Polling
+## API patterns
 
-After the initial synchronization and database population, a background monitor periodically polls that same HA API "states" endpoint. The API response also contains the current status for each state and the app uses that to update the screen and to detect changes in state values for triggering events.
+HA's REST API is the only protocol used today. Authentication is via
+a long-lived access token sent as a Bearer header, configured by the
+user. The integration polls `/api/states` (interval defined as
+`HASS_POLLING_INTERVAL_SECS` in `monitors.py`) and posts to
+`/api/services/<domain>/<service>` for control actions. There is no
+WebSocket or push-notification path — see Known limitations in the
+user-facing doc.
 
+Upstream API reference: <https://developers.home-assistant.io/docs/api/rest/>.
+
+## Implementation notes
+
+- **Capability detection is heuristic.** HA's API does not directly
+  declare what an entity can do. `HassConverter` infers state type
+  and controllability from `domain`, `device_class`, and supported
+  feature flags via the `HASS_STATE_TO_ENTITY_STATE_TYPE_MAPPING`
+  table. Read that table in `hass_converter.py` before changing
+  capability logic — it captures every mapping in one place
+  intentionally.
+- **Multi-state device aggregation.** A single physical device (e.g.,
+  a light with both `light.kitchen` and `switch.kitchen` HA entities)
+  is collapsed into one HI item where the converter can identify the
+  pairing — by Insteon address, by full-name match, or by suffix
+  rules. The grouping logic is non-trivial; see the converter's
+  device-aggregation section.
+- **Allowlist filtering.** Only HA domains and device classes named
+  in the `IMPORT_ALLOWLIST` integration attribute are imported. The
+  default list is set in `enums.py` (`HassAttributeType`).
+
+## Testing approach
+
+Tests live in `src/hi/services/hass/tests/`. The converter's mapping
+behavior is the largest test surface
+(`test_hass_converter_create.py`, `test_hass_converter_mapping.py`,
+`test_import_allowlist.py`); sync flow is exercised in
+`test_hass_sync.py`.
+
+Manual end-to-end testing uses the simulator; HA simulator support
+lives at `src/hi/simulator/services/hass/`. For the operator
+workflow and profile descriptions, see
+[`docs/dev/testing/test-simulator.md`](../testing/test-simulator.md).
+
+## References
+
+- [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/)
+- [Long-lived access tokens (HA)](https://www.home-assistant.io/docs/authentication/#your-account-profile)
+- User-facing setup: [`docs/integrations/home-assistant.md`](../../integrations/home-assistant.md)

--- a/docs/dev/integrations/homebox.md
+++ b/docs/dev/integrations/homebox.md
@@ -1,0 +1,76 @@
+# HomeBox
+
+## Overview
+
+The HomeBox integration follows the standard pattern in
+`integration-guidelines.md`, but with a narrower runtime footprint
+than HA or ZM: there are no per-item sensors or controllers and no
+real-time state changes to track. Items imported from HomeBox are
+read-only by design — they exist for placement and reference. As a
+result, `HomeBoxMonitor` does only a periodic reachability probe;
+all entity churn happens via user-initiated Import / Refresh.
+
+User-facing setup and troubleshooting live in
+[`docs/integrations/homebox.md`](../../integrations/homebox.md).
+
+## Key modules
+
+- `src/hi/services/homebox/integration.py` — `HomeBoxGateway`.
+  Framework entry point.
+- `src/hi/services/homebox/hb_manager.py` — `HomeBoxManager`.
+  Singleton holding the active `HbClient` and integration attributes.
+- `src/hi/services/homebox/hb_client.py` — `HbClient`. REST wrapper
+  around HomeBox's `/api/v1/...` endpoints, plus the
+  username/password → session-token login flow.
+- `src/hi/services/homebox/hb_converter.py` — `HbConverter`. Maps
+  HomeBox items into HI items, including custom field expansion as
+  read-only attributes.
+- `src/hi/services/homebox/hb_sync.py` — `HomeBoxSynchronizer`.
+  Drives Import / Refresh.
+- `src/hi/services/homebox/monitors.py` — `HomeBoxMonitor`. Periodic
+  reachability probe only; no state polling.
+- `src/hi/services/homebox/hb_controller.py` — `HomeBoxController`.
+  No-op controller; HomeBox items are not controllable.
+
+## API patterns
+
+HomeBox exposes a versioned REST API under `/api/v1/...`.
+Authentication is username/password to `/api/v1/users/login`,
+returning a session token used as a Bearer header for subsequent
+requests. Token refresh is handled inside `HbClient`.
+
+The user supplies the API root URL up to `/api` (without the version
+suffix); the client appends the version internally. This is
+documented in the user-facing doc and reinforced by an explicit
+error message in `HbClient` when responses are not JSON.
+
+## Implementation notes
+
+- **No live state.** HomeBox's data model is inventory metadata, not
+  device state. There is no polling cadence to tune, no sensor
+  responses to emit. The monitor exists purely for the integration
+  health-status surface.
+- **Read-only items.** Items imported from HomeBox cannot be edited
+  in HI; their HomeBox-sourced fields appear as read-only attributes.
+  The integration metadata sets `can_add_custom_attributes = False`
+  on the metadata to prevent users from adding HI-side attributes
+  that would not survive a Refresh; see `hb_metadata.py`.
+- **Attachment downloads.** Files attached to a HomeBox item
+  (manuals, receipts, photos) are downloaded into HI's media storage
+  at Import / Refresh time. Updates to the file in HomeBox propagate
+  only on the next Refresh.
+
+## Testing approach
+
+Tests live in `src/hi/services/homebox/tests/`. Coverage is
+straightforward — client, factory, converter, manager, models, sync.
+
+Manual end-to-end testing uses the simulator; HomeBox simulator
+support lives at `src/hi/simulator/services/homebox/`. For the
+operator workflow and profile descriptions, see
+[`docs/dev/testing/test-simulator.md`](../testing/test-simulator.md).
+
+## References
+
+- [HomeBox documentation](https://homebox.software/)
+- User-facing setup: [`docs/integrations/homebox.md`](../../integrations/homebox.md)

--- a/docs/dev/integrations/integration-guidelines.md
+++ b/docs/dev/integrations/integration-guidelines.md
@@ -36,6 +36,30 @@ Implement `IntegrationGateway` with required methods:
 ### 5. Register with Factory
 Add gateway mapping in `hi/integrations/integration_factory.py`
 
+### 6. Write Per-Integration Documentation
+Every user-configured integration MUST ship with two short docs based
+on the templates:
+
+- **User-facing**: copy [`docs/integrations/_template.md`](../../integrations/_template.md)
+  to `docs/integrations/<integration-name>.md` and fill in all seven
+  sections (Overview, Prerequisites, Obtaining credentials,
+  Configuration values, Setup walkthrough, Troubleshooting, Known
+  limitations).
+- **Developer-facing**: copy [`_template.md`](_template.md) to
+  `docs/dev/integrations/<integration-name>.md` and fill in all six
+  sections (Overview, Key modules, API patterns, Implementation
+  notes, Testing approach, References). Keep it high-level and refer
+  to the code for details — the code is the authoritative source.
+
+After creating both docs, add a one-paragraph entry plus a link in
+the user-facing landing page at [`docs/Integrations.md`](../../Integrations.md).
+
+> **Internal data sources** like the Weather subsystem
+> (`docs/dev/integrations/weather-integration.md`) do not require
+> per-integration user-facing docs — they are not user-configured in
+> the integration sense. The template structure above applies only to
+> integrations that appear on the Settings → Integrations page.
+
 ## Gateway Implementation Patterns
 
 ### Gateway Methods

--- a/docs/dev/integrations/weather-integration.md
+++ b/docs/dev/integrations/weather-integration.md
@@ -1,5 +1,14 @@
 # Weather Integration
 
+> **Note:** Weather is an internal data source, not a user-configured
+> integration on the Settings → Integrations page. The
+> per-integration documentation structure described in
+> [`integration-guidelines.md`](integration-guidelines.md) does not
+> apply here — Weather has no user-facing setup doc and follows a
+> different runtime architecture (auto-discovered weather sources
+> rather than the gateway/manager/sync pattern). This document is
+> the only doc you need for the Weather subsystem.
+
 ## Weather Data Source Architecture
 
 The weather system uses a pluggable integration architecture designed to support multiple external weather APIs without dependencies on any single source.

--- a/docs/dev/integrations/zoneminder.md
+++ b/docs/dev/integrations/zoneminder.md
@@ -1,0 +1,98 @@
+# ZoneMinder
+
+## Overview
+
+The ZoneMinder integration follows the standard pattern in
+`integration-guidelines.md`: a `ZoneMinderGateway` exposes the
+framework surface; a singleton `ZoneMinderManager` owns shared client
+state and the active `ZMApi` instance; the synchronizer imports each
+ZM monitor as an HI camera item with a movement sensor and a function
+controller; `ZoneMinderMonitor` polls in the background for monitor
+state and event changes.
+
+ZoneMinder ships a vendored Python client (`pyzm`) under
+`src/hi/services/zoneminder/pyzm_client/`. We use it directly rather
+than depending on the unmaintained PyPI package.
+
+User-facing setup, CORS, and SSL troubleshooting live in
+[`docs/integrations/zoneminder.md`](../../integrations/zoneminder.md).
+
+## Key modules
+
+- `src/hi/services/zoneminder/integration.py` — `ZoneMinderGateway`.
+  Framework entry point.
+- `src/hi/services/zoneminder/zm_manager.py` — `ZoneMinderManager`.
+  Singleton holding the `ZMApi` client and integration attributes;
+  also constructs the live-stream URLs from the configured
+  `PORTAL_URL`.
+- `src/hi/services/zoneminder/zm_client_factory.py` — builds and
+  validates the `ZMApi` from the integration attributes.
+- `src/hi/services/zoneminder/pyzm_client/` — vendored Python client
+  for ZM's REST API and `cgi-bin/nph-zms` streaming endpoints.
+- `src/hi/services/zoneminder/zm_sync.py` — `ZoneMinderSynchronizer`.
+  Drives Import / Refresh; per-monitor entity creation in
+  `_create_monitor_entity` (this is also the entry point used by the
+  auto-reconnect path on Refresh).
+- `src/hi/services/zoneminder/monitors.py` — `ZoneMinderMonitor`.
+  Periodic poll for monitor state, function changes, and events;
+  emits `SensorResponse` updates for movement sensor state changes.
+- `src/hi/services/zoneminder/zm_controller.py` —
+  `ZoneMinderController`. Maps HI control actions onto ZM monitor
+  function changes (Modect, Monitor, Record, etc.).
+
+## API patterns
+
+ZoneMinder's REST API is the only command/query protocol; live video
+streams use the separate `cgi-bin/nph-zms` MJPEG endpoint. Both are
+served from the user-configured `PORTAL_URL` host.
+
+Authentication is username/password via ZM's session cookie flow,
+handled by `pyzm`. There is no separate API token mechanism in
+ZoneMinder.
+
+The monitor poll cadence and per-request timeouts are defined in
+`constants.py` (`ZmTimeouts`).
+
+## Implementation notes
+
+- **Vendored `pyzm`.** The upstream `pyzm` PyPI package is not
+  actively maintained. We carry a copy of the relevant pieces under
+  `pyzm_client/` and modify it as needed. Treat that directory as a
+  third-party dependency, not as project code — keep it minimally
+  modified and document any patches inline.
+- **API URL vs. Portal URL.** ZM exposes its REST API and its web
+  portal at related but distinct paths (`.../zm/api` vs `.../zm`).
+  Both must be configured because stream URLs are built off
+  `PORTAL_URL`, not `API_URL`. See `zm_manager._stream_url(...)`
+  builders.
+- **Timezone handling.** ZM event timestamps are stored in the ZM
+  server's local time, not UTC. The configured `TIMEZONE` integration
+  attribute is used to convert them; see `zm_models.ZmEvent` /
+  `zm_manager`.
+- **Movement event lifecycle.** ZM emits motion events with start /
+  end timestamps that arrive asynchronously. The monitor correlates
+  these into HI sensor responses; see the correlation logic in
+  `monitors.py`.
+- **CORS / SSL infrastructure quirks.** The user-facing doc
+  documents the operator-side workarounds (`HI_EXTRA_CSP_URLS`
+  environment variable, nginx reverse proxy for SSL → plain HTTP).
+  These are infrastructure issues, not code-level ones, so they
+  belong in the user-facing troubleshooting section, not here.
+
+## Testing approach
+
+Tests live in `src/hi/services/zoneminder/tests/`. Sync flow,
+controller behavior, and monitor state correlation each have their
+own modules; `test_zm_sync.py` is the largest. Synthetic monitor
+data lives in `tests/synthetic_data.py` and `tests/data/`.
+
+Manual end-to-end testing uses the simulator; ZM simulator support
+lives at `src/hi/simulator/services/zoneminder/`. For the operator
+workflow and profile descriptions, see
+[`docs/dev/testing/test-simulator.md`](../testing/test-simulator.md).
+
+## References
+
+- [ZoneMinder API documentation](https://zoneminder.readthedocs.io/en/latest/api.html)
+- Upstream `pyzm` (vendored): <https://github.com/ZoneMinder/pyzm>
+- User-facing setup: [`docs/integrations/zoneminder.md`](../../integrations/zoneminder.md)

--- a/docs/dev/testing/test-simulator.md
+++ b/docs/dev/testing/test-simulator.md
@@ -22,6 +22,102 @@ cd $PROJ_DIR/src
 
 The `simulator.py` script acts just like the main `manage.py` script with all the same commands (runserver, migrate, etc.), but manages the simulator application instead.
 
+## Purpose and architecture
+
+The simulator stands in for the upstream services that real
+integrations talk to. It mounts service-shaped HTTP endpoints under
+`http://127.0.0.1:7411/services/<service>/...` that respond with the
+same shapes the real services would, sourced from a curated
+**SimProfile**. Switching profiles changes what the integrations see
+on their next Import or Refresh, which is the lever for exercising
+sync behavior end-to-end.
+
+The simulator is a separate Django app with its own database (see the
+top of this file). It does not talk to HI directly — HI's
+integration configurations point at the simulator's URLs and treat
+it as the upstream service.
+
+Per-integration simulator code lives at
+`src/hi/simulator/services/<service>/`:
+
+- `src/hi/simulator/services/hass/` — HA `/api/states` and related
+  endpoints.
+- `src/hi/simulator/services/zoneminder/` — ZM monitor and event
+  endpoints, plus an MJPEG-shaped stream endpoint.
+- `src/hi/simulator/services/homebox/` — HomeBox `/api/v1/...`
+  inventory endpoints.
+
+Each service folder typically contains `simulator.py` (the
+service-specific subclass of the `Simulator` base), `sim_models.py`
+(the field shapes the seed command writes), and `api/` (the HTTP
+views that produce the upstream-shaped responses).
+
+## Configuring HI integrations to point at the simulator
+
+Run the simulator on `127.0.0.1:7411` (the default) and configure HI
+on its own port (typically `8411`). In HI's integration Configure
+forms, paste the corresponding URL:
+
+| Integration  | HI Configure field | URL to enter                                              |
+|--------------|--------------------|-----------------------------------------------------------|
+| Home Assistant | Server URL       | `http://127.0.0.1:7411/services/hass`                     |
+| HomeBox      | API URL            | `http://127.0.0.1:7411/services/homebox/api`              |
+| ZoneMinder   | API URL            | `http://127.0.0.1:7411/services/zoneminder/api`           |
+| ZoneMinder   | Portal URL         | `http://127.0.0.1:7411/services/zoneminder/`              |
+
+For the credentials fields, any non-empty values work — the
+simulator does not validate passwords or tokens. Anything sensible
+(e.g., `simuser` / `simpass`) is fine.
+
+For the Home Assistant integration, set the **Allowed Item Types**
+to a narrow list that matches what your active SimProfile produces;
+otherwise the import will pull only the items your profile actually
+has.
+
+## Profile seeding (`seed_sim_profiles`)
+
+The `seed_sim_profiles` management command populates the simulator
+database with a curated suite of SimProfiles for manual testing. It
+is the source of every realistic upstream payload the simulator
+serves; without it the simulator is empty.
+
+```bash
+cd $PROJ_DIR/src
+./simulator.py seed_sim_profiles
+```
+
+Re-running the command is a no-op when a profile already exists.
+Pass `--reset` to delete and recreate the matching profile (and
+its entities) before recreating.
+
+After seeding, switch the simulator's active profile from the web UI
+at [http://127.0.0.1:7411](http://127.0.0.1:7411).
+
+### Profiles
+
+Five profiles are seeded, each designed to exercise a specific
+scenario. The authoritative list and per-profile contents live in
+the command's own docstring at
+`src/hi/simulator/management/commands/seed_sim_profiles.py`; the
+table below is a short orientation.
+
+| Profile            | What it exercises |
+|--------------------|-------------------|
+| `empty`            | Zero items in every integration. Tests the initial-import-with-nothing path and the refresh-against-emptied-upstream path. |
+| `baseline`         | Realistic small-install set: mixed HA device types, a handful of HomeBox items, a few ZM monitors. The "before" state for delta tests. |
+| `baseline-changed` | Same shape as `baseline` with deltas in every integration. Pairing it with `baseline` exercises the five sync-result categories — created, updated, reconnected, detached, removed — in a single flip. |
+| `hass-zoo`         | One HA entity of every supported type. Visual / grouping coverage for the HASS converter; HomeBox and ZM stay empty. |
+| `volume`           | Large counts (30 HA, 25 HomeBox, 10 ZM monitors). Stresses modal list overflow scrolling and dispatcher group sizing. |
+
+### Operator workflow for full-category sync-result coverage
+
+The `baseline ↔ baseline-changed` pair is the canonical workflow for
+exercising every sync-result category. The command's docstring
+spells out the exact step-by-step (which entities to add custom
+attributes to, what each Refresh shows in the result modal); read
+it directly when running the workflow rather than trying to keep a
+copy of the steps here in sync.
+
 ## Dependencies
 
 ### Python 3.11

--- a/docs/integrations/_template.md
+++ b/docs/integrations/_template.md
@@ -1,0 +1,102 @@
+<!--
+  TEMPLATE — copy this file to docs/integrations/<integration-name>.md
+  and fill in each section.
+
+  Goal: give a user enough to set up the integration, recognize and fix
+  the most common failures, and know what this integration does and
+  does not do. Short is fine — no section needs to be long. Write for
+  someone who has never used HI's integrations before.
+-->
+
+<img src="../../src/hi/static/img/hi-logo-w-tagline-197x96.png" alt="Home Information Logo" width="128">
+
+# <Integration Name>
+
+## Overview
+
+One short paragraph: what this integration is for, what kinds of items
+it imports into HI, and the use cases it best serves. Avoid marketing
+language; describe behavior.
+
+Introduce **Home Information (HI)** by full name on first mention,
+then use the **HI** abbreviation thereafter. Same convention for
+upstream services with common abbreviations (e.g., **Home Assistant
+(HA)**) — full name first, abbreviation after.
+
+Use **item** (not "entity") when referring to HI's own
+representation. Reserve **entity** / **entities** for the upstream
+service when that is the term that service uses (HA, for example,
+calls them entities, so "HA entity" is correct in that context).
+
+## Prerequisites
+
+What the user must have running or installed on their side before
+configuring this integration in HI. List concretely:
+
+- Service version supported / minimum tested.
+- Network reachability requirements (must be reachable from the HI
+  server; same LAN; reverse proxy considerations).
+- Any account, API key, or admin permission the user must already
+  have.
+
+## Obtaining credentials
+
+Step-by-step instructions specific to this service. Use a numbered
+list. Where the upstream service has its own documentation for the
+step, link to it rather than restating.
+
+Screenshots are optional but encouraged when a credential-acquisition
+step is non-obvious (hidden menu, required role, etc.).
+
+1. ...
+2. ...
+3. ...
+
+## Configuration values
+
+Map exactly what the user enters into each field of HI's Configure
+form for this integration. Include URL format details that are easy to
+get wrong (scheme, port, path suffix, trailing slash).
+
+| Field | What to enter | Notes |
+|-------|---------------|-------|
+| ... | ... | ... |
+
+## Setup walkthrough
+
+What the user does in HI to enable the integration once they have
+their credentials, and what to expect on the first **Import**. Keep
+this brief — it is mostly continuity from the previous section into
+the post-import state.
+
+The standard first step is opening HI's integration picker — link
+back to [Enabling an integration](../Integrations.md#enabling-an-integration)
+for the conditional UI flow rather than restating it here, so a UI
+change only needs to be reflected in one place.
+
+Use the user-facing terms: **Import** for the first run and
+**Refresh** for subsequent runs (matching the modal labels). Avoid
+"sync" in user-facing copy.
+
+## Troubleshooting
+
+Common errors and their fixes. Treat this as an accreting list — add
+entries here as real-world issues surface, rather than aiming for
+completeness up front.
+
+### <Symptom or error message>
+
+What it usually means and how to fix it.
+
+### <Symptom or error message>
+
+...
+
+## Known limitations
+
+Things this integration does not do, or does differently from what a
+new user might reasonably expect. State them plainly so users do not
+spend time looking for features that are not there.
+
+- ...
+- ...

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -1,0 +1,108 @@
+<img src="../../src/hi/static/img/hi-logo-w-tagline-197x96.png" alt="Home Information Logo" width="128">
+
+# Home Assistant
+
+## Overview
+
+Home Assistant (HA) is a general-purpose home-automation platform with
+broad device and protocol support. The HA integration imports HA
+entities into Home Information (HI) as items and keeps their states
+current via polling. For controllable items, HI dispatches control
+actions back to HA.
+
+In practice, the integration has been exercised end-to-end with
+switches, outlets, open/close sensors, and motion sensors. The
+default allowlist also requests other HA domains (lights, cameras,
+climate, covers, locks, fans, media players) — the code attempts to
+map them, but those types have not been verified against real
+devices. See [Known limitations](#known-limitations).
+
+## Prerequisites
+
+- A running Home Assistant instance, network-reachable from the host
+  running HI.
+- An account in HA with permission to create a long-lived access
+  token.
+- HA's default REST API enabled (it is on by default in standard
+  installs).
+
+## Obtaining credentials
+
+HI authenticates against HA using a long-lived access token.
+
+1. In Home Assistant, click your user profile (lower-left of the
+   sidebar).
+2. Open the **Security** tab.
+3. Scroll to **Long-lived access tokens** and click **Create
+   token**.
+4. Give the token a name (e.g., `home-information`) and copy the
+   value. HA displays it once — store it before navigating away.
+
+See HA's official guide for screenshots and updates if the UI changes:
+[Home Assistant — Long-lived access tokens](https://www.home-assistant.io/docs/authentication/#your-account-profile).
+
+## Configuration values
+
+| Field | What to enter | Notes |
+|-------|---------------|-------|
+| Server URL | The HA root URL, e.g. `https://hass.local:8123` | No `/api` suffix — HI appends it. Trailing slash is ignored. |
+| API Token | The long-lived access token from the previous section. | |
+| Add Alarm Events | Whether to auto-create alarm rules for connectivity, open/close, motion, and battery sensors at import time. | Defaults to enabled. |
+| Allowed Item Types | HA domains and device classes to import, one per line. Use `domain` for all classes, or `domain:class` for specific ones. | Defaults to `binary_sensor`, `camera`, `climate`, `cover`, `fan`, `light`, `lock`, `media_player`, `sensor`, `switch`. The default list reflects what the code attempts to map; only a subset (switches, outlets, open/close, motion) has been verified against real devices. Narrow the list to reduce noise from HA installs that expose many irrelevant entities. |
+
+## Setup walkthrough
+
+1. Open HI's integration picker (see
+   [Enabling an integration](../Integrations.md#enabling-an-integration))
+   and choose **Home Assistant**.
+2. Fill in the four fields above and save.
+3. HI walks you through a series of modals to confirm the **Import**
+   action, pull HA entities that match the allowlist, and place the
+   imported items into a location view or collection. Capability
+   detection uses heuristics over HA's domain and device class
+   metadata.
+
+To pick up changes from HA later (new entities, renames, removals),
+click **REFRESH** on the integration's manage page.
+
+## Troubleshooting
+
+### Connection refused / cannot reach server
+
+The Server URL is wrong, the HA server is not reachable from the HI
+host, or HA's default port is not `8123`. Verify by opening the
+Server URL in a browser from the HI host and confirming the HA login
+page loads.
+
+### 401 Unauthorized
+
+The API Token is invalid, was revoked, or was copied incompletely.
+Recreate the token in HA and paste it again — HA only shows the
+token value once at creation.
+
+### Self-signed SSL certificate
+
+If HA is served over HTTPS with a self-signed cert, browsers and
+Python's TLS layer will reject it by default. Either install a
+trusted certificate (e.g., via reverse proxy with Let's Encrypt) or
+serve HA over plain HTTP on a trusted local network.
+
+## Known limitations
+
+- **Verified device coverage is narrower than the allowlist
+  suggests.** Switches, outlets, open/close sensors, and motion
+  sensors have been tested end-to-end. The other defaults (lights,
+  cameras, climate, covers, locks, fans, media players) have code
+  paths but have not been exercised against real devices — capability
+  detection or control may not work as expected. If you rely on one
+  of those types, expect to file issues and iterate.
+- Capability detection is heuristic. HA's API does not always
+  declare what an entity can do; HI infers controllability and state
+  type from `domain`, `device_class`, and supported feature flags.
+  Some entities may be imported as sensors when they are actually
+  controllable, or vice versa.
+- Multi-state HA devices (e.g., a single physical light exposed as
+  both a `light.` and a `switch.` entity) are deduplicated where
+  possible, but the heuristics are not perfect.
+- Polling cadence is fixed; there is no push-notification path from
+  HA into HI yet.

--- a/docs/integrations/homebox.md
+++ b/docs/integrations/homebox.md
@@ -1,0 +1,85 @@
+<img src="../../src/hi/static/img/hi-logo-w-tagline-197x96.png" alt="Home Information Logo" width="128">
+
+# HomeBox
+
+## Overview
+
+HomeBox is an open-source home inventory system for tracking
+household items, warranties, and documentation. The HomeBox
+integration imports each HomeBox item into Home Information (HI) as
+an HI item with the metadata and custom fields exposed as read-only
+attributes; attached files (manuals, receipts, photos) are
+downloaded alongside. HomeBox is an inventory source — items are
+not controllable, and there are no sensors or events.
+
+## Prerequisites
+
+- A running HomeBox instance, network-reachable from the host running
+  HI.
+- A HomeBox account that can sign in to the HomeBox web UI. HI uses
+  the same credentials.
+
+## Obtaining credentials
+
+HomeBox uses the same username and password you use to log into the
+HomeBox web interface — there is no separate API token to obtain.
+
+1. Confirm your HomeBox login works in the web UI.
+2. Use the same username and password in the HI configuration below.
+
+## Configuration values
+
+| Field | What to enter | Notes |
+|-------|---------------|-------|
+| API URL | The HomeBox API root, e.g. `https://homebox.local/api` | Must include the `/api` path. Do not include the version (e.g., not `/api/v1`) — HI appends the version itself. Trailing slash is ignored. |
+| Username | Your HomeBox login username (or email, depending on how your HomeBox is configured). | |
+| Password | Your HomeBox login password. | Stored encrypted at rest. |
+
+## Setup walkthrough
+
+1. Open HI's integration picker (see
+   [Enabling an integration](../Integrations.md#enabling-an-integration))
+   and choose **HomeBox**.
+2. Fill in the three fields above and save.
+3. HI walks you through a series of modals to confirm the **Import**
+   action, pull each HomeBox item as an HI item, and place the
+   imported items into a location view or collection. Custom fields
+   become read-only attributes; attached files are downloaded to
+   HI's media storage.
+
+To pick up changes from HomeBox later (new items, renames,
+removals), click **REFRESH** on the integration's manage page.
+
+## Troubleshooting
+
+### Connection refused / cannot reach server
+
+The API URL is wrong or the HomeBox server is not reachable from the
+HI host. Verify by opening the API URL in a browser from the HI host
+— a healthy HomeBox API root returns a JSON status response (not a
+404).
+
+### "Ensure the URL includes the API path"
+
+The error means HI received a non-JSON response. The most common
+cause is omitting the `/api` suffix from the URL — HI is hitting the
+HomeBox web frontend instead of the API. Update the URL to include
+`/api`.
+
+### 401 / login failures
+
+The username or password is wrong, or the HomeBox account is
+disabled. Verify by logging into the HomeBox web UI directly with
+the same credentials.
+
+## Known limitations
+
+- HomeBox items are imported read-only. There are no sensors,
+  controllers, or alarm events for HomeBox items — they exist
+  primarily for placement and reference.
+- Custom attributes added in HI on a HomeBox-imported item are
+  preserved across Refresh, but HomeBox-sourced fields cannot be
+  edited from within HI; edit them in HomeBox and Refresh.
+- Attached files are downloaded at import / Refresh time. Updates to
+  a file in HomeBox (replacing a manual PDF, for instance) require a
+  Refresh to propagate.

--- a/docs/integrations/zoneminder.md
+++ b/docs/integrations/zoneminder.md
@@ -1,0 +1,112 @@
+<img src="../../src/hi/static/img/hi-logo-w-tagline-197x96.png" alt="Home Information Logo" width="128">
+
+# ZoneMinder
+
+## Overview
+
+ZoneMinder (ZM) is an open-source video surveillance system. The ZM
+integration imports each ZM monitor into Home Information (HI) as a
+camera item with a motion sensor and a function controller, and
+provides live video streams in the camera detail view. HI does not
+run image analysis itself — motion events come from ZM's own
+detection.
+
+## Prerequisites
+
+- A running ZoneMinder instance, network-reachable from the host
+  running HI.
+- An account in ZM with API access. The default `admin` account works;
+  a dedicated user with API permission is recommended.
+- The ZM API enabled. Recent ZM versions enable it by default; older
+  installs may need it turned on in the ZM options.
+
+## Obtaining credentials
+
+HI authenticates against ZM with a username and password. There is no
+separate API token mechanism in ZoneMinder.
+
+1. Log in to your ZoneMinder web portal as an administrator.
+2. Either use your administrator credentials, or under
+   **Options → Users**, create a dedicated user for HI with API
+   access enabled.
+3. Note the username and password for the next section.
+
+## Configuration values
+
+| Field | What to enter | Notes |
+|-------|---------------|-------|
+| API URL | The ZM API root, e.g. `https://zm.local:8443/zm/api` | Path typically ends in `/zm/api`. Do not include a trailing slash. |
+| Portal URL | The ZM web portal root, e.g. `https://zm.local:8443/zm` | Same host as API URL but without the `/api` suffix. Used for video stream URLs (`cgi-bin/nph-zms`). |
+| Username | The ZM account username from the previous section. | |
+| Password | The corresponding password. | Stored encrypted at rest. |
+| Timezone | Your ZM server's timezone (e.g., `America/Chicago`). | ZM stores event timestamps in its server-local time; HI uses this to convert them. |
+| Add Alarm Events | Whether to auto-create alarm rules for monitor motion events at import time. | Defaults to enabled. |
+
+## Setup walkthrough
+
+1. Open HI's integration picker (see
+   [Enabling an integration](../Integrations.md#enabling-an-integration))
+   and choose **ZoneMinder**.
+2. Fill in the six fields above and save.
+3. HI walks you through a series of modals to confirm the **Import**
+   action, pull each ZM monitor as an HI camera item, and place the
+   imported cameras into a location view or collection.
+
+To pick up changes from ZoneMinder later (new monitors, renames,
+removals), click **REFRESH** on the integration's manage page.
+
+## Troubleshooting
+
+### Camera streams will not play (CORS)
+
+Browsers refuse to load video frames from a different origin unless
+the server's Content Security Policy (CSP) explicitly allows it. If
+your ZM server is on a different host or port than HI, you must add
+the ZM origin to HI's allowed CSP URLs:
+
+```shell
+export HI_EXTRA_CSP_URLS="${SCHEME}://${HOST}:${PORT}"
+```
+
+Set this in the environment of the running HI process (e.g., your
+service unit file or shell profile) and restart HI.
+
+### Mixed-content errors (HTTP page, HTTPS streams)
+
+If HI itself is served over HTTP but ZM is served over HTTPS,
+browsers block the HTTPS streams from loading into the HTTP page on
+security grounds. The same rejection happens — even more
+aggressively — when ZM uses a self-signed certificate (the default
+on many installs).
+
+The workaround that has worked for us: stand up an nginx reverse
+proxy in front of ZM that terminates SSL and serves the streams as
+plain HTTP back to HI. Update ZM's **Portal URL** option to the
+proxy URL so the stream paths HI generates point at the proxy
+instead of the SSL endpoint.
+
+### Connection refused / cannot reach server
+
+The API URL or Portal URL is wrong, or the ZM server is not reachable
+from the HI host. Verify by opening the Portal URL in a browser from
+the HI host and confirming the ZM login page loads.
+
+### 401 / login failures
+
+The username or password is wrong, the user does not have API access
+permission in ZM, or the ZM API is disabled. Verify by logging into
+the ZM portal directly with the same credentials, then check
+**Options → Users** for the user's API permission flag.
+
+## Known limitations
+
+- HI does not run any image analysis or motion detection — all motion
+  events originate from ZM. Configure detection sensitivity and
+  zones in ZM itself.
+- ZM monitor renames in the upstream are propagated on Refresh; ZM
+  monitor deletes remove the corresponding HI camera unless the user
+  has added custom data to it (in which case it is preserved as
+  detached, with a "Detached from ZoneMinder" indicator).
+- Live stream playback depends on ZM's `cgi-bin/nph-zms` endpoint
+  being reachable from the user's browser, not just from the HI
+  server. The CORS and SSL issues above are common consequences.


### PR DESCRIPTION
## Pull Request: Issue #280 — Per-integration documentation structure and content

### Issue Link

Closes #280

---

## Category

- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [x] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)

- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Two-track per-integration documentation structure (user-facing + developer-facing), populated for the three existing integrations and made required for new ones.

**Templates and conventions** (Phase 1):
- New `docs/integrations/_template.md` — user-facing template, seven required sections.
- New `docs/dev/integrations/_template.md` — developer-facing template, six required sections; explicitly directs writers to keep content high-level and refer to the code for details rather than duplicating signatures or field lists.
- Updated `docs/dev/integrations/integration-guidelines.md` — adds Step 6 to the integration-addition checklist requiring both per-integration docs.

**User-facing per-integration docs** (Phase 2):
- New `docs/integrations/{home-assistant,zoneminder,homebox}.md`. ZoneMinder doc incorporates the existing CORS and HTTPS/SSL troubleshooting content migrated out of the shared `Integrations.md`.
- Restructured `docs/Integrations.md` as a short landing page that centralizes the conditional UI flow for enabling an integration (different button label and location depending on whether any are configured yet) so per-integration pages can link to it instead of restating it.
- Conventions documented in the user-facing template and applied across all four files: introduce **Home Information (HI)** on first mention; use **item** for HI's representation, reserve **entity** for upstream services that use that term (e.g., HA); use **Import** (first run) and **Refresh** (subsequent), not "sync", in user-facing copy.

**Developer-facing per-integration docs** (Phase 3):
- New `docs/dev/integrations/{zoneminder,homebox}.md`; existing `home-assistant.md` expanded from a single section to all six required sections.
- `docs/dev/integrations/weather-integration.md` gets a one-paragraph preface marking it as an internal-source exception that does not follow the per-integration template structure.

**Simulator documentation** (Phase 4):
- `docs/dev/testing/test-simulator.md` expanded with three new sections: simulator purpose and architecture; URL mappings for pointing each HI integration at the simulator; the `seed_sim_profiles` command (with a profile summary table and a pointer to the command's docstring for the full operator workflow).

---

## How to Test

This is a docs-only change; verification is by reading the rendered output.

1. Navigate to `docs/Integrations.md` — confirm the landing page reads naturally, the **Enabling an integration** section captures both UI states (no integrations configured yet vs. at least one), and the three Available Integrations links resolve.
2. Open each per-integration user doc (`docs/integrations/{home-assistant,zoneminder,homebox}.md`) — confirm the seven required sections are present, configuration values match the actual Configure-form fields, and ZoneMinder's CORS / HTTPS-SSL troubleshooting content is correctly migrated.
3. Open each per-integration dev doc (`docs/dev/integrations/{home-assistant,zoneminder,homebox}.md`) — spot-check the "Key modules" section against the actual files; confirm the dev docs avoid duplicating method signatures or field-list details from the code.
4. Open `docs/dev/testing/test-simulator.md` — confirm the integration-to-simulator URL mappings are correct (`http://127.0.0.1:7411/services/{hass,homebox/api,zoneminder/api,zoneminder/}`) and the profile summary table aligns with what `seed_sim_profiles` actually creates.
5. Open `docs/dev/integrations/integration-guidelines.md` — confirm the new Step 6 requiring per-integration doc creation appears in the right place in the existing numbered list, with working links to both templates.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary. (Docs-only change; no test changes.)
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

## Additional Notes

A few stylistic decisions made during the work that future readers may want to know about:

- **Filename convention** for the new files is **kebab-case** (e.g., `home-assistant.md`), matching the existing `docs/dev/` convention. The existing CamelCase top-level docs (`GettingStarted.md`, `Installation.md`, etc.) are left alone — retrofitting them is out of scope for this issue. Recommend filing a separate housekeeping issue if you want to unify the convention later.
- **Templates use the `_` prefix** (`_template.md`) to signal "skeleton, not real content."
- **Weather** is treated as an internal data source per the issue's recommendation (option a), with a single-paragraph preface added to its existing dev doc rather than restructuring it.

---

### **Reviewer(s)**

@cassandra
