### PR TITLE
HA integration EntityType handling: domain coverage, user-owned fields, name-based inference

### DIFF
--- a/src/hi/services/hass/hass_converter.py
+++ b/src/hi/services/hass/hass_converter.py
@@ -1146,13 +1146,36 @@ class HassConverter:
         if ( HassApi.LIGHT_DOMAIN in domain_set
              or HassApi.LIGHT_DEVICE_CLASS in device_class_set ):
             return EntityType.LIGHT
+        # Outlet device class wins over the generic switch domain
+        # branch below — an HA switch.x with device_class=outlet is
+        # specifically an electrical outlet, not a wall switch.
         if HassApi.OUTLET_DEVICE_CLASS in device_class_set:
-            return EntityType.WALL_SWITCH
+            return EntityType.ELECTRICAL_OUTLET
+        if HassApi.SWITCH_DOMAIN in domain_set:
+            return EntityType.ON_OFF_SWITCH
+        if HassApi.LOCK_DOMAIN in domain_set:
+            return EntityType.DOOR_LOCK
+        # HA covers are doors / windows / garage doors / blinds /
+        # awnings / etc. Without a device-class refinement that maps
+        # cleanly to HI's specific types, OPEN_CLOSE_SENSOR is the
+        # least-wrong default; the operator can change it post-import
+        # to DOOR / WINDOW / GARAGE_DOOR if appropriate.
+        if HassApi.COVER_DOMAIN in domain_set:
+            return EntityType.OPEN_CLOSE_SENSOR
+        # Fan domain has no HA-side device class to distinguish
+        # ceiling vs exhaust; CEILING_FAN is the more common case.
+        if HassApi.FAN_DOMAIN in domain_set:
+            return EntityType.CEILING_FAN
+        # Climate domain is the controllable HVAC entity; the
+        # temperature device-class check below catches passive
+        # temperature sensors that aren't climate entities.
+        if HassApi.CLIMATE_DOMAIN in domain_set:
+            return EntityType.THERMOSTAT
         if HassApi.TEMPERATURE_DEVICE_CLASS in device_class_set:
             return EntityType.THERMOSTAT
         if HassApi.CONNECTIVITY_DEVICE_CLASS in device_class_set:
             return EntityType.HEALTHCHECK
-  
+
         return EntityType.OTHER
             
     @classmethod

--- a/src/hi/services/hass/hass_converter.py
+++ b/src/hi/services/hass/hass_converter.py
@@ -534,22 +534,21 @@ class HassConverter:
     
     @classmethod
     def update_models_for_hass_device( cls, entity : Entity, hass_device : HassDevice ) -> List[str]:
+        """Refresh integration-owned components on an existing entity.
+
+        ``entity.name`` and ``entity.entity_type`` are user-editable
+        in HI's UI on HASS entities (``can_add_custom_attributes``
+        defaults to True), so they're treated as user-owned after
+        creation: this method does not touch them on update. The
+        operator's choice of name and type sticks across refreshes.
+        Symmetric to the create-vs-reconnect distinction in
+        ``create_models_for_hass_device``, which already preserves
+        ``name`` on the reconnect path.
+        """
 
         messages = list()
         with transaction.atomic():
 
-            entity_name = cls.hass_device_to_entity_name( hass_device )
-            entity_type = cls.hass_device_to_entity_type( hass_device )
-            if entity.name != entity_name:
-                messages.append(f'Name changed for {entity}. Setting to "{entity_name}"')
-                entity.name = entity_name
-                entity.save()
-
-            if entity.entity_type != entity_type:
-                messages.append(f'Type changed for {entity}. Setting to "{entity_type}"')
-                entity.entity_type = entity_type
-                entity.save()
-            
             insteon_address = cls.hass_device_to_insteon_address( hass_device )
             try:
                 attribute = entity.attributes.get( name = cls.INSTEON_ADDRESS_ATTR_NAME )

--- a/src/hi/services/hass/hass_converter.py
+++ b/src/hi/services/hass/hass_converter.py
@@ -1126,6 +1126,50 @@ class HassConverter:
             return friendly_name
         return hass_device.device_id
         
+    # Word-boundary patterns matched against the device's display
+    # name to upgrade a switch-domain device's EntityType at import
+    # time when the name reveals what the switch is wired to. Word
+    # boundaries guard against substring collisions (e.g.
+    # "Lighthouse", "Lightning" don't match the bare "light"
+    # keyword). Each regex is paired with the EntityType it implies
+    # in ``_NAME_INFERENCE_RULES`` below.
+    _OUTLET_NAME_PATTERN = re.compile(
+        r'\b(plug|plugs|outlet|outlets|receptacle|receptacles)\b',
+        re.IGNORECASE,
+    )
+    _FAN_NAME_PATTERN = re.compile(
+        r'\b(fan|fans)\b',
+        re.IGNORECASE,
+    )
+    _LIGHT_NAME_PATTERN = re.compile(
+        r'\b(light|lights|lighting'
+        r'|lamp|lamps|bulb|bulbs|led|sconce|chandelier'
+        r'|pendant|spotlight|floodlight|lantern)\b',
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _device_name_to_inferred_type(
+            cls, hass_device : HassDevice ) -> Optional[EntityType]:
+        """Heuristic mapping for a switch-domain device whose name
+        reveals what it's connected to. Order encodes precedence:
+        outlet/plug keywords are most specific (a "Smart Plug" is
+        almost always wanted as ELECTRICAL_OUTLET), fan next, light
+        last. Returns None when no rule matches; the caller falls
+        through to the generic ON_OFF_SWITCH for switch-domain
+        devices. False positives cost one manual edit which now
+        sticks across refreshes."""
+        name = cls.hass_device_to_entity_name( hass_device )
+        if not name:
+            return None
+        if cls._OUTLET_NAME_PATTERN.search( name ):
+            return EntityType.ELECTRICAL_OUTLET
+        if cls._FAN_NAME_PATTERN.search( name ):
+            return EntityType.CEILING_FAN
+        if cls._LIGHT_NAME_PATTERN.search( name ):
+            return EntityType.LIGHT
+        return None
+
     @classmethod
     def hass_device_to_entity_type( cls, hass_device : HassDevice ) -> EntityType:
         domain_set = hass_device.domain_set
@@ -1145,12 +1189,20 @@ class HassConverter:
         if ( HassApi.LIGHT_DOMAIN in domain_set
              or HassApi.LIGHT_DEVICE_CLASS in device_class_set ):
             return EntityType.LIGHT
-        # Outlet device class wins over the generic switch domain
-        # branch below — an HA switch.x with device_class=outlet is
+        # Outlet device class wins over the switch-domain branch
+        # below — an HA switch.x with device_class=outlet is
         # specifically an electrical outlet, not a wall switch.
         if HassApi.OUTLET_DEVICE_CLASS in device_class_set:
             return EntityType.ELECTRICAL_OUTLET
+        # For a generic switch.x device, the name often reveals
+        # what the switch is wired to (Kitchen Light, Smart Plug,
+        # Ceiling Fan); the heuristic upgrades the type at import
+        # time when a clear match is present, falling through to
+        # the catch-all ON_OFF_SWITCH otherwise.
         if HassApi.SWITCH_DOMAIN in domain_set:
+            inferred = cls._device_name_to_inferred_type( hass_device )
+            if inferred is not None:
+                return inferred
             return EntityType.ON_OFF_SWITCH
         if HassApi.LOCK_DOMAIN in domain_set:
             return EntityType.DOOR_LOCK

--- a/src/hi/services/hass/tests/test_hass_converter_create.py
+++ b/src/hi/services/hass/tests/test_hass_converter_create.py
@@ -161,6 +161,61 @@ class CreateModelsForHassDeviceReconnectContractTests(TestCase):
         self.assertIsNotNone(existing.integration_name)
 
 
+class UpdateModelsForHassDeviceContractTests(TestCase):
+    """Pin that ``update_models_for_hass_device`` treats user-editable
+    fields (``name``, ``entity_type``) as user-owned after creation.
+    HASS entities default ``can_add_custom_attributes=True`` so the
+    operator can edit name/type via the entity-edit modal; once
+    edited, refreshes must not silently revert those changes."""
+
+    def _build_simple_light_device(self, device_id='kitchen_light'):
+        api_dict = {
+            'entity_id': f'light.{device_id}',
+            'state': 'on',
+            'attributes': {
+                'friendly_name': device_id.replace('_', ' ').title(),
+                'supported_color_modes': ['onoff'],
+                'color_mode': 'onoff',
+            },
+            'last_changed': '2026-01-01T00:00:00+00:00',
+            'last_reported': '2026-01-01T00:00:00+00:00',
+            'last_updated': '2026-01-01T00:00:00+00:00',
+            'context': {'id': 'ctx', 'parent_id': None, 'user_id': None},
+        }
+        hass_state = HassConverter.create_hass_state(api_dict)
+        device = HassDevice(device_id=device_id)
+        device.add_state(hass_state)
+        return device
+
+    def test_update_preserves_user_edited_name(self):
+        existing = Entity.objects.create(
+            name='Operator Picked Name',
+            entity_type_str='WALL_SWITCH',
+        )
+        device = self._build_simple_light_device()
+
+        HassConverter.update_models_for_hass_device(
+            entity=existing, hass_device=device,
+        )
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.name, 'Operator Picked Name')
+
+    def test_update_preserves_user_edited_entity_type(self):
+        existing = Entity.objects.create(
+            name='Kitchen Light',
+            entity_type_str='WALL_SWITCH',  # operator chose switch icon for a light
+        )
+        device = self._build_simple_light_device()
+
+        HassConverter.update_models_for_hass_device(
+            entity=existing, hass_device=device,
+        )
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.entity_type_str, 'WALL_SWITCH')
+
+
 class EventDefinitionLifecycleCycleTests(TestCase):
     """
     Issue #288 Phase 3: end-to-end EventDefinition lifecycle for HASS

--- a/src/hi/services/hass/tests/test_hass_converter_entity_type.py
+++ b/src/hi/services/hass/tests/test_hass_converter_entity_type.py
@@ -1,0 +1,100 @@
+import logging
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from hi.apps.entity.enums import EntityType
+from hi.services.hass.hass_converter import HassConverter
+from hi.services.hass.hass_models import HassApi, HassDevice
+
+logging.disable(logging.CRITICAL)
+
+
+class HassDeviceToEntityTypeTests( TestCase ):
+    """Pin the domain/device-class → EntityType mapping. Each branch
+    is exercised with the smallest fake HassDevice that satisfies
+    the predicate; a switch-domain regression where generic switches
+    fell through to OTHER motivated the broader sweep."""
+
+    @staticmethod
+    def _device( domain_set = None, device_class_set = None ) -> HassDevice:
+        device = Mock( spec = HassDevice )
+        device.domain_set = set( domain_set or [] )
+        device.device_class_set = set( device_class_set or [] )
+        return device
+
+    def test_switch_domain_maps_to_on_off_switch( self ):
+        device = self._device( domain_set = { HassApi.SWITCH_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.ON_OFF_SWITCH,
+        )
+
+    def test_outlet_device_class_takes_precedence_over_switch_domain( self ):
+        device = self._device(
+            domain_set = { HassApi.SWITCH_DOMAIN },
+            device_class_set = { HassApi.OUTLET_DEVICE_CLASS },
+        )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.ELECTRICAL_OUTLET,
+        )
+
+    def test_lock_domain_maps_to_door_lock( self ):
+        device = self._device( domain_set = { HassApi.LOCK_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.DOOR_LOCK,
+        )
+
+    def test_cover_domain_maps_to_open_close_sensor( self ):
+        device = self._device( domain_set = { HassApi.COVER_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.OPEN_CLOSE_SENSOR,
+        )
+
+    def test_fan_domain_maps_to_ceiling_fan( self ):
+        device = self._device( domain_set = { HassApi.FAN_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.CEILING_FAN,
+        )
+
+    def test_climate_domain_maps_to_thermostat( self ):
+        device = self._device( domain_set = { HassApi.CLIMATE_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.THERMOSTAT,
+        )
+
+    def test_camera_domain_maps_to_camera( self ):
+        device = self._device( domain_set = { HassApi.CAMERA_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.CAMERA,
+        )
+
+    def test_light_domain_maps_to_light( self ):
+        device = self._device( domain_set = { HassApi.LIGHT_DOMAIN } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.LIGHT,
+        )
+
+    def test_motion_device_class_maps_to_motion_sensor( self ):
+        device = self._device(
+            domain_set = { HassApi.BINARY_SENSOR_DOMAIN },
+            device_class_set = { HassApi.MOTION_DEVICE_CLASS },
+        )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.MOTION_SENSOR,
+        )
+
+    def test_unknown_domain_falls_through_to_other( self ):
+        device = self._device( domain_set = { 'something_unrecognized' } )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.OTHER,
+        )

--- a/src/hi/services/hass/tests/test_hass_converter_entity_type.py
+++ b/src/hi/services/hass/tests/test_hass_converter_entity_type.py
@@ -1,5 +1,4 @@
 import logging
-from unittest.mock import Mock
 
 from django.test import TestCase
 
@@ -10,30 +9,59 @@ from hi.services.hass.hass_models import HassApi, HassDevice
 logging.disable(logging.CRITICAL)
 
 
+def _make_device(
+        entity_id     : str,
+        friendly_name : str = '',
+        device_class  : str = None,
+) -> HassDevice:
+    """Construct a minimal real HassDevice with a single state. The
+    state's ``entity_id`` drives ``domain_set`` (the prefix before
+    ``.``) and the ``device_class`` attribute drives
+    ``device_class_set``. ``friendly_name`` populates the name the
+    converter exposes via ``hass_device_to_entity_name`` — used by
+    the light-name heuristic. Avoids mocking so the converter
+    runs over genuine HassDevice / HassState objects."""
+    attributes = {}
+    if friendly_name:
+        attributes[HassApi.FRIENDLY_NAME_ATTR] = friendly_name
+    if device_class is not None:
+        attributes[HassApi.DEVICE_CLASS_ATTR] = device_class
+    api_dict = {
+        'entity_id'    : entity_id,
+        'state'        : 'off',
+        'attributes'   : attributes,
+        'last_changed' : '2026-01-01T00:00:00+00:00',
+        'last_reported': '2026-01-01T00:00:00+00:00',
+        'last_updated' : '2026-01-01T00:00:00+00:00',
+        'context'      : { 'id': 'ctx', 'parent_id': None, 'user_id': None },
+    }
+    state = HassConverter.create_hass_state( api_dict )
+    device_id = entity_id.split( '.', 1 )[1] if '.' in entity_id else entity_id
+    device = HassDevice( device_id = device_id )
+    device.add_state( state )
+    return device
+
+
 class HassDeviceToEntityTypeTests( TestCase ):
-    """Pin the domain/device-class → EntityType mapping. Each branch
-    is exercised with the smallest fake HassDevice that satisfies
-    the predicate; a switch-domain regression where generic switches
-    fell through to OTHER motivated the broader sweep."""
+    """Pin the domain/device-class → EntityType mapping. Each test
+    builds a minimal real HassDevice that carries the predicate
+    being exercised; a switch-domain regression where generic
+    switches fell through to OTHER motivated the broader sweep."""
 
-    @staticmethod
-    def _device( domain_set = None, device_class_set = None ) -> HassDevice:
-        device = Mock( spec = HassDevice )
-        device.domain_set = set( domain_set or [] )
-        device.device_class_set = set( device_class_set or [] )
-        return device
-
-    def test_switch_domain_maps_to_on_off_switch( self ):
-        device = self._device( domain_set = { HassApi.SWITCH_DOMAIN } )
+    def test_switch_domain_with_neutral_name_maps_to_on_off_switch( self ):
+        device = _make_device(
+            entity_id = 'switch.relay_a', friendly_name = 'Garage Relay',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.ON_OFF_SWITCH,
         )
 
     def test_outlet_device_class_takes_precedence_over_switch_domain( self ):
-        device = self._device(
-            domain_set = { HassApi.SWITCH_DOMAIN },
-            device_class_set = { HassApi.OUTLET_DEVICE_CLASS },
+        device = _make_device(
+            entity_id = 'switch.outlet_a',
+            friendly_name = 'Garage Outlet',
+            device_class = HassApi.OUTLET_DEVICE_CLASS,
         )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
@@ -41,51 +69,64 @@ class HassDeviceToEntityTypeTests( TestCase ):
         )
 
     def test_lock_domain_maps_to_door_lock( self ):
-        device = self._device( domain_set = { HassApi.LOCK_DOMAIN } )
+        device = _make_device(
+            entity_id = 'lock.front_door', friendly_name = 'Front Door',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.DOOR_LOCK,
         )
 
     def test_cover_domain_maps_to_open_close_sensor( self ):
-        device = self._device( domain_set = { HassApi.COVER_DOMAIN } )
+        device = _make_device(
+            entity_id = 'cover.bedroom_blinds', friendly_name = 'Bedroom Blinds',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.OPEN_CLOSE_SENSOR,
         )
 
     def test_fan_domain_maps_to_ceiling_fan( self ):
-        device = self._device( domain_set = { HassApi.FAN_DOMAIN } )
+        device = _make_device(
+            entity_id = 'fan.living_room', friendly_name = 'Living Room Fan',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.CEILING_FAN,
         )
 
     def test_climate_domain_maps_to_thermostat( self ):
-        device = self._device( domain_set = { HassApi.CLIMATE_DOMAIN } )
+        device = _make_device(
+            entity_id = 'climate.upstairs', friendly_name = 'Upstairs',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.THERMOSTAT,
         )
 
     def test_camera_domain_maps_to_camera( self ):
-        device = self._device( domain_set = { HassApi.CAMERA_DOMAIN } )
+        device = _make_device(
+            entity_id = 'camera.front_door', friendly_name = 'Front Door Cam',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.CAMERA,
         )
 
     def test_light_domain_maps_to_light( self ):
-        device = self._device( domain_set = { HassApi.LIGHT_DOMAIN } )
+        device = _make_device(
+            entity_id = 'light.kitchen_main', friendly_name = 'Kitchen Main',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.LIGHT,
         )
 
     def test_motion_device_class_maps_to_motion_sensor( self ):
-        device = self._device(
-            domain_set = { HassApi.BINARY_SENSOR_DOMAIN },
-            device_class_set = { HassApi.MOTION_DEVICE_CLASS },
+        device = _make_device(
+            entity_id = 'binary_sensor.hallway',
+            friendly_name = 'Hallway',
+            device_class = HassApi.MOTION_DEVICE_CLASS,
         )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
@@ -93,8 +134,168 @@ class HassDeviceToEntityTypeTests( TestCase ):
         )
 
     def test_unknown_domain_falls_through_to_other( self ):
-        device = self._device( domain_set = { 'something_unrecognized' } )
+        device = _make_device(
+            entity_id = 'unknown_domain.thing', friendly_name = 'Thing',
+        )
         self.assertEqual(
             HassConverter.hass_device_to_entity_type( device ),
             EntityType.OTHER,
+        )
+
+
+class HassSwitchNameInferenceTests( TestCase ):
+    """Switch-domain devices whose name reveals what they're wired
+    to are pre-typed at import time to spare the operator the
+    per-entity edit. Three keyword groups, in precedence order:
+    outlet/plug → ELECTRICAL_OUTLET, fan → CEILING_FAN, light →
+    LIGHT. Tests cover each keyword family plus precedence and
+    word-boundary false-positive guards."""
+
+    def _entity_type_for_name( self, friendly_name : str ) -> EntityType:
+        device = _make_device(
+            entity_id = 'switch.relay_a', friendly_name = friendly_name,
+        )
+        return HassConverter.hass_device_to_entity_type( device )
+
+    # ----- light family -----
+
+    def test_switch_named_light_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Kitchen Light' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_lights_plural_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Bedroom Lights' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_lighting_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Cabinet Lighting' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_lamp_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Living Room Lamp' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_led_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Hallway LED' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_chandelier_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Dining Chandelier' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_pendant_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Foyer Pendant' ),
+            EntityType.LIGHT,
+        )
+
+    def test_switch_named_floodlight_promotes_to_light( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Backyard Floodlight' ),
+            EntityType.LIGHT,
+        )
+
+    # ----- outlet family -----
+
+    def test_switch_named_smart_plug_promotes_to_outlet( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Smart Plug' ),
+            EntityType.ELECTRICAL_OUTLET,
+        )
+
+    def test_switch_named_outlet_promotes_to_outlet( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Workshop Outlet' ),
+            EntityType.ELECTRICAL_OUTLET,
+        )
+
+    def test_switch_named_receptacle_promotes_to_outlet( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Garage Receptacle' ),
+            EntityType.ELECTRICAL_OUTLET,
+        )
+
+    # ----- fan family -----
+
+    def test_switch_named_fan_promotes_to_ceiling_fan( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Bathroom Fan' ),
+            EntityType.CEILING_FAN,
+        )
+
+    def test_switch_named_ceiling_fan_promotes_to_ceiling_fan( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Bedroom Ceiling Fan' ),
+            EntityType.CEILING_FAN,
+        )
+
+    # ----- precedence -----
+
+    def test_outlet_keyword_wins_over_light_keyword( self ):
+        """A switch named with both an outlet and a light keyword
+        ('Lamp Plug') resolves as ELECTRICAL_OUTLET — outlet rule
+        runs first and is the more specific signal about the
+        device's nature (it's a plug; the load is incidental)."""
+        self.assertEqual(
+            self._entity_type_for_name( 'Lamp Plug' ),
+            EntityType.ELECTRICAL_OUTLET,
+        )
+
+    def test_fan_keyword_wins_over_light_keyword( self ):
+        """'Ceiling Fan Light' matches both fan and light keywords;
+        fan rule fires first. Imperfect for combination switches
+        controlling both, but the operator can edit (and a single
+        switch controlling both fan and light is uncommon — usually
+        they're separate switches with separate names)."""
+        self.assertEqual(
+            self._entity_type_for_name( 'Ceiling Fan Light' ),
+            EntityType.CEILING_FAN,
+        )
+
+    # ----- false-positive guards -----
+
+    def test_switch_named_smart_relay_falls_through_to_on_off_switch( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Smart Relay' ),
+            EntityType.ON_OFF_SWITCH,
+        )
+
+    def test_switch_with_substring_lighthouse_does_not_match( self ):
+        """Word-boundary regex prevents 'Lighthouse Decor' from
+        matching the 'light' keyword via substring."""
+        self.assertEqual(
+            self._entity_type_for_name( 'Lighthouse Decor' ),
+            EntityType.ON_OFF_SWITCH,
+        )
+
+    def test_switch_with_substring_lightning_does_not_match( self ):
+        self.assertEqual(
+            self._entity_type_for_name( 'Lightning Sensor' ),
+            EntityType.ON_OFF_SWITCH,
+        )
+
+    def test_outlet_device_class_still_wins_over_name_heuristic( self ):
+        """A switch.x with device_class=outlet is an outlet
+        regardless of its friendly name; outlet device-class
+        check fires before the name-inference dispatch."""
+        device = _make_device(
+            entity_id = 'switch.outlet_a',
+            friendly_name = 'Lamp Outlet',
+            device_class = HassApi.OUTLET_DEVICE_CLASS,
+        )
+        self.assertEqual(
+            HassConverter.hass_device_to_entity_type( device ),
+            EntityType.ELECTRICAL_OUTLET,
         )

--- a/src/hi/services/zoneminder/tests/test_zm_sync.py
+++ b/src/hi/services/zoneminder/tests/test_zm_sync.py
@@ -545,41 +545,42 @@ class TestZoneMinderSynchronizerEntityUpdate(TestCase):
     def setUp(self):
         self.synchronizer = ZoneMinderSynchronizer()
     
-    def test_update_entity_changes_name_when_different(self):
-        """Test _update_entity updates name when monitor name changed and preserves other attributes"""
+    def test_update_entity_preserves_user_edited_name(self):
+        """Operator-edited names are user-owned after creation; an
+        upstream rename in ZoneMinder does not propagate. The
+        operator's chosen name stays put across refreshes."""
         mock_entity = Mock()
-        mock_entity.name = 'Old Name'
+        mock_entity.name = 'Operator Name'
         mock_entity.id = 123
         mock_entity.entity_type_str = 'CAMERA'
         mock_entity.can_user_delete = True
         original_integration_key = Mock()
         mock_entity.integration_key = original_integration_key
         mock_entity.save = Mock()
-        
+
         mock_monitor = Mock()
-        mock_monitor.name.return_value = 'New Name'
+        mock_monitor.name.return_value = 'Upstream Renamed'
         mock_monitor.id.return_value = 456
-        
+
         result = IntegrationSyncResult(title='Test')
         self.synchronizer._update_entity(mock_entity, mock_monitor, result)
-        
-        # Test name update behavior
-        self.assertEqual(mock_entity.name, 'New Name')
-        mock_entity.save.assert_called_once()
-        
-        # Test preservation of other critical attributes
-        self.assertEqual(mock_entity.id, 123)  # Entity ID unchanged
-        self.assertEqual(mock_entity.entity_type_str, 'CAMERA')  # Type unchanged
-        self.assertEqual(mock_entity.can_user_delete, True)  # User delete flag unchanged
-        self.assertEqual(mock_entity.integration_key, original_integration_key)  # Integration key unchanged
-        
-        # Rename surfaces the old → new transition in updated_list
-        # (operator can see both names at a glance).
-        self.assertEqual(len(result.error_list), 0)
-        self.assertEqual(result.updated_list, ['Old Name → New Name'])
 
-    def test_update_entity_no_change_when_name_same(self):
-        """Test _update_entity doesn't save when name unchanged and preserves all entity state"""
+        # Name preserved despite upstream rename.
+        self.assertEqual(mock_entity.name, 'Operator Name')
+        mock_entity.save.assert_not_called()
+
+        # Other entity state untouched.
+        self.assertEqual(mock_entity.entity_type_str, 'CAMERA')
+        self.assertEqual(mock_entity.can_user_delete, True)
+        self.assertEqual(mock_entity.integration_key, original_integration_key)
+
+        # No rename message — there's no rename to surface.
+        self.assertEqual(len(result.error_list), 0)
+        self.assertEqual(result.updated_list, [])
+
+    def test_update_entity_no_persistence_when_name_same(self):
+        """No-op even when names happen to match — the method
+        intentionally does not touch user-owned name on update."""
         mock_entity = Mock()
         mock_entity.name = 'Same Name'
         mock_entity.id = 789
@@ -593,10 +594,7 @@ class TestZoneMinderSynchronizerEntityUpdate(TestCase):
         result = IntegrationSyncResult(title='Test')
         self.synchronizer._update_entity(mock_entity, mock_monitor, result)
 
-        # Test no persistence when no changes.
         mock_entity.save.assert_not_called()
-
-        # No-change path appends nothing and surfaces nothing.
         self.assertEqual(len(result.error_list), 0)
         self.assertEqual(result.updated_list, [])
         self.assertEqual(result.info_list, [])
@@ -779,22 +777,21 @@ class TestZoneMinderSynchronizerWithRealData(TestCase):
         self.assertIn('ROTATE_0', orientations)
         self.assertIn('ROTATE_270', orientations)
     
-    def test_update_entity_with_real_monitor_name_changes(self):
-        """Test entity updates with realistic monitor name scenarios"""
-        # Create scenario where monitor name changed from generic to real name
+    def test_update_entity_preserves_operator_name_against_real_monitor_data(self):
+        """Even with a real-shaped ZM monitor object, the operator's
+        chosen name persists on update — the integration treats
+        entity name as user-owned after creation."""
         mock_entity = Mock()
-        mock_entity.name = 'Camera_001'  # Generic name
-        
-        # Use real monitor data
+        mock_entity.name = 'Operator Renamed Cam'
+
         real_monitor = self.create_mock_monitors_from_real_data()[0]  # HighCamera
-        
+
         result = IntegrationSyncResult(title='Test')
         self.synchronizer._update_entity(mock_entity, real_monitor, result)
-        
-        # Should update to real name from ZM API
-        self.assertEqual(mock_entity.name, 'HighCamera')
-        mock_entity.save.assert_called_once()
-        self.assertEqual(result.updated_list, ['Camera_001 → HighCamera'])
+
+        self.assertEqual(mock_entity.name, 'Operator Renamed Cam')
+        mock_entity.save.assert_not_called()
+        self.assertEqual(result.updated_list, [])
     
     @patch('hi.services.zoneminder.zm_sync.Entity.objects.filter')
     def test_get_existing_entities_with_real_monitor_id_patterns(self, mock_filter):

--- a/src/hi/services/zoneminder/zm_sync.py
+++ b/src/hi/services/zoneminder/zm_sync.py
@@ -369,12 +369,17 @@ class ZoneMinderSynchronizer( IntegrationSynchronizer, ZoneMinderMixin ):
                         entity      : Entity,
                         zm_monitor  : ZmMonitor,
                         result      : IntegrationSyncResult ):
-        if entity.name != zm_monitor.name():
-            old_name = entity.name
-            entity.name = zm_monitor.name()
-            entity.save()
-            # Surface the rename so the operator sees both names.
-            result.updated_list.append( f'{old_name} → {entity.name}' )
+        """Refresh integration-owned components on an existing entity.
+
+        ``entity.name`` is user-editable in HI's UI on ZM entities
+        (``can_add_custom_attributes`` defaults to True), so it's
+        treated as user-owned after creation: this method does not
+        touch it on update. ZM monitor renames upstream are not
+        propagated; the operator's chosen name stays. The method is
+        currently a no-op stub kept for the symmetry of the sync
+        flow's create/update/remove dispatch — future
+        integration-owned per-entity fields would land here.
+        """
         return
     
     def _remove_entity( self,


### PR DESCRIPTION
## Pull Request: HA integration EntityType handling: domain coverage, user-owned fields, name-based inference

### Issue Link
N/A — three small improvements collected on a tweaks branch, similar in spirit to PR #293.

---

## Category
- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [x] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Three discrete changes that improve how HI handles HA entity types on import and refresh. Each is its own commit.

### 1. Map common HA domains to specific EntityTypes instead of OTHER (`ccbadd4f`)

`hass_device_to_entity_type` had no clauses for the `switch`, `lock`, `cover`, `fan`, or `climate` domains; HA devices in any of those domains without a recognized `device_class` fell through to `EntityType.OTHER`. Generic switches (`switch.foo` with no device_class) were the most visible regression. Added per-domain branches:

- `switch` → `ON_OFF_SWITCH`
- `lock` → `DOOR_LOCK`
- `cover` → `OPEN_CLOSE_SENSOR` (catch-all; finer DOOR/WINDOW/GARAGE_DOOR refinement was considered and deferred — those are path-based area types whose auto-promotion would force operators into a heavier placement workflow at import time and risk visual duplication against the architectural floor-plan SVG)
- `fan` → `CEILING_FAN`
- `climate` → `THERMOSTAT`

Plus corrected `device_class=outlet` → `ELECTRICAL_OUTLET` (was `WALL_SWITCH`); the outlet check is ordered ahead of the new switch-domain branch so outlet-flavored switches keep precedence. New `test_hass_converter_entity_type.py` pins each branch and the precedence ordering.

### 2. Treat entity name and type as user-owned across HASS and ZM refreshes (`fda9ea5e`)

The HASS and ZM update paths were overwriting `entity.name` (and `entity.entity_type` for HASS) with the integration's mapped values on every refresh, silently reverting any edits the operator made via the entity-edit modal. Both integrations let users edit those fields (`can_add_custom_attributes` defaults to True), so they're supposed to be user-owned post-creation. Dropped the overwrite logic on the HASS update path and the ZM `_update_entity` rename branch.

HomeBox is intentionally untouched — its `can_add_custom_attributes=False` and the entity-edit modal makes those fields read-only, so its full overwrite-on-update is consistent there. New tests on both HASS and ZM lock in the design intent so regressions surface.

### 3. Promote HA switch EntityType from name-based heuristic at import (`9d712eef`)

Generic HA `switch.x` devices land as `ON_OFF_SWITCH` by default, but the operator's name often reveals what the switch is wired to. Added a small set of word-boundary keyword regexes that infer a more specific `EntityType` from the device's display name when no device-class-driven mapping fires:

- outlet/plug/receptacle keywords → `ELECTRICAL_OUTLET`
- fan keywords → `CEILING_FAN`
- light/lamp/bulb/lighting/pendant/spotlight/floodlight/lantern/sconce/chandelier/LED keywords → `LIGHT`

Outlet rule runs first (most specific signal — a "Smart Plug" is the device's nature; the load is incidental), fan next, light last. The `device_class=outlet` shortcut still wins over name inference. The entity-type stickiness fix from change #2 means false positives now cost only one manual edit. Word boundaries guard against substring collisions (`Lighthouse`, `Lightning` don't match `light`).

---

## How to Test

The full suite passes (`make test` — 2618 tests, 3 skipped). For manual verification:

1. **Domain coverage** (#1): import an HA configuration that includes a generic `switch.x` (no device_class), a `lock.x`, a `cover.x`, a `fan.x`, and a `climate.x`. Each should land as the specific EntityType per the mapping above (not `OTHER`).
2. **User-owned name/type stickiness** (#2): in HI, edit a HASS or ZM entity's name and entity_type via the entity-edit modal. Trigger a Refresh. The edits should persist; previously they were overwritten.
3. **Switch-name inference** (#3): import an HA `switch.x` named "Kitchen Light" — should land as `LIGHT` rather than `ON_OFF_SWITCH`. Same for "Smart Plug" → `ELECTRICAL_OUTLET`, "Bathroom Fan" → `CEILING_FAN`. A generic name like "Smart Relay" stays `ON_OFF_SWITCH`.

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

#293 (the previous tweaks-branch collection — same pattern of small improvements grouped onto a `tweaks/*` branch).

---

## Screenshots (if applicable)

N/A

---

## Additional Notes

The cover-domain catch-all to `OPEN_CLOSE_SENSOR` rather than DOOR/WINDOW/GARAGE_DOOR is deliberate; see commit `ccbadd4f`'s message and the in-code comment for rationale (path-based area types vs drag-and-drop placement).

The HomeBox integration is intentionally not touched by change #2 — its read-only entity-edit UI is consistent with the integration's full overwrite-on-update.

Follow-on work tracked separately in #294 (parent meta-issue for expanded HA device coverage in the simulator) and its child issues #295–#301.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
