### PR TITLE
Security: Potential XSS in custom template filter attribute_text_linkify

### DIFF
--- a/src/hi/apps/attribute/templates/attribute/components/value_types/attribute_value_text.html
+++ b/src/hi/apps/attribute/templates/attribute/components/value_types/attribute_value_text.html
@@ -29,7 +29,7 @@ New/unsaved TEXT forms start directly in edit mode.
     <div class="{{ DIVID.ATTR_V2_TEXT_READ_CONTENT_CLASS }}{% if overflows > 0 %} is-collapsed{% endif %}"
         {% if attribute_form.instance.is_editable %}onclick="Hi.attr.handleTextReadContentClick(event)" style="cursor: text;"{% endif %}>
       {% if value_text %}
-        {{ value_text|attribute_text_linkify }}
+        {{ value_text|escape|attribute_text_linkify }}
       {% else %}
         &nbsp;
       {% endif %}


### PR DESCRIPTION
## Summary

Security: Potential XSS in custom template filter attribute_text_linkify

## Problem

**Severity**: `High` | **File**: `src/hi/apps/attribute/templates/attribute/components/value_types/attribute_value_text.html:L27`

The template 'attribute_value_text.html' uses a custom filter 'attribute_text_linkify' to convert text to links. If this filter doesn't properly sanitize HTML, it could lead to XSS attacks. The filter is used as: `{{ value_text|attribute_text_linkify }}`. Without proper sanitization, malicious input could inject JavaScript.

## Solution

Ensure the 'attribute_text_linkify' template filter properly sanitizes HTML to prevent XSS. Use Django's escape filter or a proper HTML sanitization library before converting URLs to links.

## Changes

- `src/hi/apps/attribute/templates/attribute/components/value_types/attribute_value_text.html` (modified)