### PR TITLE
Add replay-from-start affordance for video recordings

### DIFF
--- a/src/hi/apps/alert/templates/alert/modals/alert_details.html
+++ b/src/hi/apps/alert/templates/alert/modals/alert_details.html
@@ -59,7 +59,10 @@
         </h6>
       </div>
       <div class="card-body p-2">
-        <img class="img-fluid" data-video-stream src="{{ video_stream.source_url }}" alt="{{ alert_visual_content.alarm.title }}">
+        <div class="hi-video-recording">
+          <img class="img-fluid" data-video-recording src="{{ video_stream.source_url }}" alt="{{ alert_visual_content.alarm.title }}">
+          {% include "console/panes/video_recording_replay_button.html" %}
+        </div>
         {% if not alert_visual_content.is_from_latest %}
         <small class="text-muted d-block mt-1">From: {{ alert_visual_content.alarm.timestamp|localtime|date:"M j, Y H:i" }}</small>
         {% endif %}
@@ -113,7 +116,10 @@
                   <small class="text-muted">Source {{ video_source.index }} - {{ video_source.alarm.timestamp|localtime|date:"M j H:i" }}</small>
                 </div>
                 <div class="card-body p-2">
-                  <img class="img-fluid" data-video-stream src="{{ video_stream.source_url }}" alt="Source {{ video_source.index }}">
+                  <div class="hi-video-recording">
+                    <img class="img-fluid" data-video-recording src="{{ video_stream.source_url }}" alt="Source {{ video_source.index }}">
+                    {% include "console/panes/video_recording_replay_button.html" %}
+                  </div>
                 </div>
               </div>
               {% endif %}

--- a/src/hi/apps/alert/templates/alert/panes/alarm_sensor_response.html
+++ b/src/hi/apps/alert/templates/alert/panes/alarm_sensor_response.html
@@ -5,7 +5,10 @@
     {% sensor_response_video_stream sensor_response as video_stream %}
     {% if video_stream and video_stream.source_url %}
     <div class="mb-2">
-      <img class="img-fluid" data-video-stream src="{{ video_stream.source_url }}" alt="{{ alarm.title }}">
+      <div class="hi-video-recording">
+        <img class="img-fluid" data-video-recording src="{{ video_stream.source_url }}" alt="{{ alarm.title }}">
+        {% include "console/panes/video_recording_replay_button.html" %}
+      </div>
     </div>
     {% elif sensor_response.source_image_url %}
     <!-- Fallback to image when video stream is not available -->

--- a/src/hi/apps/console/templates/console/panes/entity_video_sensor_history.html
+++ b/src/hi/apps/console/templates/console/panes/entity_video_sensor_history.html
@@ -115,7 +115,10 @@
                 <div class="video-container mb-3" role="img" aria-label="Event video playback">
                     {% sensor_response_video_stream sensor_history_data.current_sensor_response as video_stream %}
                     {% if video_stream and video_stream.source_url %}
-                    <img class="img-fluid" data-video-stream src="{{ video_stream.source_url }}" alt="Video recording from {{ sensor_history_data.current_sensor_response.timestamp|localtime|date:'F j, Y g:i A' }}" data-event-id="{{ sensor_history_data.current_sensor_response.sensor_history_id }}" onerror="this.style.display='none'; this.outerHTML='<div class=\'alert alert-warning text-center d-flex align-items-center justify-content-center\' style=\'min-height: 240px;\'><div><div class=\'mb-2\'>[VIDEO]</div><h6>Video No Longer Available</h6></div></div>'">
+                    <div class="hi-video-recording">
+                      <img class="img-fluid" data-video-recording src="{{ video_stream.source_url }}" alt="Video recording from {{ sensor_history_data.current_sensor_response.timestamp|localtime|date:'F j, Y g:i A' }}" data-event-id="{{ sensor_history_data.current_sensor_response.sensor_history_id }}" onerror="this.style.display='none'; this.outerHTML='<div class=\'alert alert-warning text-center d-flex align-items-center justify-content-center\' style=\'min-height: 240px;\'><div><div class=\'mb-2\'>[VIDEO]</div><h6>Video No Longer Available</h6></div></div>'">
+                      {% include "console/panes/video_recording_replay_button.html" %}
+                    </div>
                     {% elif sensor_history_data.current_sensor_response.source_image_url %}
                     <!-- Fallback to image when video stream is not available -->
                     <img class="img-fluid" src="{{ sensor_history_data.current_sensor_response.source_image_url }}" alt="Image from {{ sensor_history_data.current_sensor_response.timestamp|localtime|date:'F j, Y g:i A' }}" data-event-id="{{ sensor_history_data.current_sensor_response.sensor_history_id }}">

--- a/src/hi/apps/console/templates/console/panes/video_recording_replay_button.html
+++ b/src/hi/apps/console/templates/console/panes/video_recording_replay_button.html
@@ -1,0 +1,11 @@
+{% load icons %}
+{# Replay-from-start affordance for a ``<img data-video-recording>``  #}
+{# element. Expected to sit inside a ``.hi-video-recording`` wrapper  #}
+{# alongside the img; the wrapper provides ``position: relative`` so  #}
+{# this button anchors to the top-right of the video frame. The      #}
+{# click handler (delegated in video-timeline.js) re-fetches the     #}
+{# img's URL to play the recording from the start.                   #}
+<button type="button" class="hi-video-recording-replay"
+        title="Replay from start" aria-label="Replay from start">
+  {% icon "rotate" size="sm" %}
+</button>

--- a/src/hi/apps/sense/templates/sense/modals/sensor_history_details.html
+++ b/src/hi/apps/sense/templates/sense/modals/sensor_history_details.html
@@ -13,7 +13,10 @@ Sensor Response Details
       {% sensor_response_video_stream sensor_response as video_stream %}
       {% if video_stream and video_stream.source_url %}
       <div>
-        <img class="img-fluid" data-video-stream src="{{ video_stream.source_url }}" alt="Sensor History">
+        <div class="hi-video-recording">
+          <img class="img-fluid" data-video-recording src="{{ video_stream.source_url }}" alt="Sensor History">
+          {% include "console/panes/video_recording_replay_button.html" %}
+        </div>
       </div>
       {% elif sensor_response.source_image_url %}
       <!-- Fallback to image when video stream is not available -->

--- a/src/hi/static/css/main.css
+++ b/src/hi/static/css/main.css
@@ -2241,3 +2241,70 @@ g[hover] {
     max-height: 200px;
     overflow-y: auto;
 }
+
+/* Wrapper around a finite-recording <img> + its replay-from-start
+   overlay button. ``position: relative`` anchors the button to the
+   image's top-right; ``display: block`` and ``line-height: 0`` let
+   the wrapper shrink to the image's actual rendered dimensions so
+   the overlay sits on the image, not on padding around it. */
+.hi-video-recording {
+    position: relative;
+    display: block;
+    line-height: 0;
+}
+
+/* Replay-from-start overlay button. Always visible (touch screens
+   don't reliably support hover-reveal), semi-transparent backdrop
+   so it reads against any video content underneath. */
+.hi-video-recording-replay {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0.85;
+    transition: opacity 0.15s ease, background-color 0.15s ease,
+                transform 0.05s ease;
+    line-height: 1;
+    z-index: 1;
+
+    /* Touch-friendly behavior on tablets / phones. */
+    touch-action: manipulation;            /* no 300ms tap delay */
+    -webkit-tap-highlight-color: transparent;  /* suppress iOS gray flash */
+    -webkit-touch-callout: none;           /* no long-press callout */
+    user-select: none;
+}
+
+/* Extend the hit area outward to ~48x48 without changing the visual
+   size of the button — meets the WCAG 2.5.5 / Apple HIG / Material
+   touch-target guidance while keeping the icon compact on the video
+   frame. Pseudo-element shares the button's pointer-events, so taps
+   in the extended area dispatch the click handler. */
+.hi-video-recording-replay::before {
+    content: '';
+    position: absolute;
+    top: -8px;
+    left: -8px;
+    right: -8px;
+    bottom: -8px;
+}
+
+.hi-video-recording-replay:hover,
+.hi-video-recording-replay:focus {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.75);
+    outline: none;
+}
+.hi-video-recording-replay:active {
+    background: rgba(0, 0, 0, 0.9);
+    transform: scale(0.92);
+}

--- a/src/hi/static/js/video-timeline.js
+++ b/src/hi/static/js/video-timeline.js
@@ -8,12 +8,19 @@
     const TRANSPARENT_GIF_SRC =
         'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
+    // The connection manager treats both markers as the same kind of
+    // long-lived MJPEG fetch — both need explicit cleanup on DOM
+    // removal so browser per-host connection slots are released. The
+    // markers themselves are disjoint by content type:
+    //   - ``data-video-stream``    : continuous live MJPEG (camera).
+    //   - ``data-video-recording`` : finite recorded MJPEG (event playback).
+    // The replay click handler at the bottom of this file applies
+    // only to the recording case.
+    const LONG_LIVED_VIDEO_SELECTOR =
+        'img[data-video-stream], img[data-video-recording]';
+
     // Tracks every long-lived video connection currently attached to
-    // the document. An <img> opts in by carrying ``data-video-stream``;
-    // both live MJPEG streams and event-video playback elements need
-    // this because surveillance users typically browse between events
-    // faster than playback completes, leaving recorded-video fetches
-    // holding browser per-host connection slots if not closed.
+    // the document.
     //
     // Responsibilities split with antinode:
     //   - Antinode fires ``beforeAsyncRender($target)`` immediately
@@ -59,7 +66,7 @@
         closeWithin: function( $scope ) {
             if ( ! $scope || ! $scope.find ) return;
             const manager = this;
-            $scope.find( 'img[data-video-stream]' ).each(function() {
+            $scope.find( LONG_LIVED_VIDEO_SELECTOR ).each(function() {
                 manager.forceClose( this );
             });
         },
@@ -72,7 +79,7 @@
                     this.streams.delete( element );
                 }
             }
-            document.querySelectorAll( 'img[data-video-stream]' ).forEach(
+            document.querySelectorAll( LONG_LIVED_VIDEO_SELECTOR ).forEach(
                 (el) => this.register( el )
             );
         },
@@ -179,7 +186,7 @@
             // Tag the current video element with its event id for
             // debug visibility in console logs / DOM inspection. The
             // connection manager handles registration itself via the
-            // ``data-video-stream`` marker.
+            // ``data-video-stream`` / ``data-video-recording`` markers.
             this.tagCurrentVideoWithEventId();
         },
 
@@ -244,6 +251,43 @@
     // Also cleanup on navigation away from video pages
     window.addEventListener('pagehide', () => {
         VideoConnectionManager.cleanup();
+    });
+
+    // Replay-from-start for finite recordings. Templates wrap each
+    // ``[data-video-recording]`` <img> in a ``.hi-video-recording``
+    // container that also holds a ``.hi-video-recording-replay``
+    // button. Delegated on body so async-loaded fragments work
+    // without an init pass.
+    //
+    // Mechanism: append a fresh ``_replay`` query parameter to the
+    // cached original URL on each click. The browser sees a new URL,
+    // abandons the previous fetch, and starts a new one. ZoneMinder
+    // serves the recording from the start on each request
+    // (``replay=single``). Avoids ever blanking the ``src`` —
+    // some templates carry inline ``onerror`` handlers that fire
+    // on empty src and replace the <img> with an error message,
+    // which the empty-src + reset technique would trigger.
+    function videoRecordingReplayBuster( baseUrl ) {
+        const sep = baseUrl.includes('?') ? '&' : '?';
+        return baseUrl + sep + '_replay=' + Date.now();
+    }
+    jQuery(function($) {
+        $( 'body' ).on( 'click', '.hi-video-recording-replay', function( ev ) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            const wrapper = this.closest( '.hi-video-recording' );
+            const img = wrapper && wrapper.querySelector( 'img[data-video-recording]' );
+            if ( ! img ) return;
+            // Cache the original URL on first click. Subsequent
+            // clicks always rebuild from this cached base so the
+            // ``_replay`` parameter doesn't stack.
+            if ( ! img.dataset.videoRecordingSrc ) {
+                img.dataset.videoRecordingSrc = img.src;
+            }
+            const baseUrl = img.dataset.videoRecordingSrc;
+            if ( ! baseUrl || baseUrl.startsWith('data:') ) return;
+            img.src = videoRecordingReplayBuster( baseUrl );
+        });
     });
 
 

--- a/src/hi/templates/service-worker.js
+++ b/src/hi/templates/service-worker.js
@@ -1,37 +1,24 @@
-// Static-asset cache + pass-through for everything else.
+// Pass-through service worker.
 //
-// The service worker intercepts only requests whose path begins with
-// Django's STATIC_URL. Cache-first with on-demand population on miss.
-// Everything else — dynamic pages, the polling endpoint, MJPEG video
-// streams (multipart/x-mixed-replace) — passes through to the
-// browser's native fetch path. Firefox in particular mishandles
-// multiple concurrent multipart streams routed through a service
-// worker's respondWith, so this scoping is deliberate.
-
-var CACHE_VERSION = 2;
-var STATIC_CACHE_NAME = 'static-cache-' + CACHE_VERSION;
-var STATIC_URL_PREFIX = '{{ STATIC_URL }}';
+// Registered solely to satisfy the installable-PWA criteria
+// (manifest + active SW with a fetch handler). No caching: the
+// browser's HTTP cache handles repeat fetches for /static/ assets,
+// and adding a SW cache layer on top introduced stale-content bugs
+// every time a static file changed (cache key is the URL, which
+// doesn't change between deploys).
 
 self.addEventListener('install', function(event) {
-  // Take over immediately rather than waiting for all existing
-  // controlled pages to close. Combined with ``clients.claim()`` on
-  // activate, this ensures the new SW handles fetches as soon as it
-  // is installed.
   event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener('activate', function(event) {
-  // Sweep any caches that don't match the current version. Bumping
-  // CACHE_VERSION invalidates everything previously cached.
+  // Sweep every cache this SW has ever created so users upgrading
+  // from a caching version don't keep serving stale content.
   event.waitUntil(
     caches.keys().then(function(cacheNames) {
-      return Promise.all(
-        cacheNames.map(function(name) {
-          if (name !== STATIC_CACHE_NAME) {
-            return caches.delete(name);
-          }
-        })
-      );
+      return Promise.all(cacheNames.map(function(name) {
+        return caches.delete(name);
+      }));
     }).then(function() {
       return self.clients.claim();
     })
@@ -39,30 +26,7 @@ self.addEventListener('activate', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
-  if (event.request.method !== 'GET') {
-    return;
-  }
-  if (!event.request.url.startsWith('http')) {
-    return;
-  }
-  var pathname = new URL(event.request.url).pathname;
-  if (!pathname.startsWith(STATIC_URL_PREFIX)) {
-    return;
-  }
-  event.respondWith(
-    caches.match(event.request).then(function(cached) {
-      if (cached) {
-        return cached;
-      }
-      return fetch(event.request).then(function(response) {
-        if (response && response.ok) {
-          var clone = response.clone();
-          caches.open(STATIC_CACHE_NAME).then(function(cache) {
-            cache.put(event.request, clone);
-          });
-        }
-        return response;
-      });
-    })
-  );
+  // Intentional no-op: let the browser handle every request
+  // natively. Present only to satisfy PWA installability checks
+  // that look for a fetch handler on the active SW.
 });


### PR DESCRIPTION
## Pull Request: Add replay-from-start affordance for video recordings

### Issue Link

No tracking issue — this UX improvement came up conversationally while reviewing the alert details modal behavior.

---

## Category

- [x] **Feature** (New functionality) — adds a replay button to event-video displays
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [x] **Refactor** (Code improvements without changing functionality) — splits the overloaded `data-video-stream` marker into two content-typed markers
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Finite event-video recordings are displayed in several modal and collapsed-section contexts where, once played through, there was no way to re-watch from start without navigating away and back. The worst case is the alert details modal — which collapses extra event cards by default — where the videos in collapsed sections still fetch in the DOM and play through before the user expands the section, leaving only the final frame visible by the time they look.

**Marker split.** The previously-overloaded `data-video-stream` is split into two content-typed markers:
- `data-video-stream` — continuous live MJPEG (the camera live view).
- `data-video-recording` — finite recorded MJPEG (event playback).

These are mutually exclusive. The connection manager (which needs cleanup for both) queries the union; the new replay affordance queries only `data-video-recording`.

**Replay affordance.** Each recording `<img>` is wrapped in `<div class="hi-video-recording">` alongside a small `<button class="hi-video-recording-replay">` from a shared partial template. A single delegated click handler on `body` listens for the button click and replays the video.

**Replay mechanism.** Appends a fresh `_replay=<timestamp>` query parameter to the cached original URL. The browser sees a new URL, abandons the previous fetch, and starts a new one; ZoneMinder serves the recording from the start on each request (`replay=single`). The URL-buster approach was chosen over a clear-and-reset technique because the entity video sensor history template carries an inline `onerror` handler that fires on empty `src` and destroys the `<img>`.

**Touch-friendly button.**
- Visible 32×32 icon with the hit area extended to 48×48 via a `::before` pseudo-element (meets WCAG 2.5.5 minimum touch target without enlarging the visual).
- `touch-action: manipulation` (no 300ms tap delay).
- `-webkit-tap-highlight-color: transparent` (suppress iOS gray flash).
- `-webkit-touch-callout: none` + `user-select: none` (block iOS long-press context menu).
- `:active` state with darker background + `scale(0.92)` for visible tap feedback.

**Drop service-worker static-asset cache layer.** Bundled in this PR because it surfaced as the root cause of replay-button intermittency during development: the SW served pre-PR cached `main.css` (missing position rules → button mis-rendered) and pre-PR cached `video-timeline.js` (missing the new click handler → button click did nothing), with no console errors and only sporadic hard-refresh recovery. The cache-first strategy keyed by unchanging static URLs produced stale-content bugs on every static file change and required a manual `CACHE_VERSION` bump on each deploy. The browser's HTTP cache already handles repeat-fetch speedups for `/static/`; the SW cache layer added a recurring staleness failure mode without offering a capability the browser doesn't already provide. The fetch handler is now a no-op (kept only for PWA installability), and activate wipes every prior cache so existing users upgrade cleanly.

---

## How to Test

**Quality gates:**
1. `make test` — full suite passes.
2. `make lint` — clean.

**Manual verification (desktop + tablet):**

1. **Alert details modal — single video.** Open an alert whose primary alarm has a video. Confirm a small replay icon overlay sits in the top-right corner of the video. Let the video play through (or click during playback). Tap the icon — video restarts from the beginning.

2. **Alert details modal — multiple video sources.** Open an alert with multiple alarms (video_source_count >= 4). Expand the collapsed video-sources list. Each card has its own replay button. Clicking replays just that card's video.

3. **Alert pane / alarm sensor response.** Inline alarm-card video on the alert pane — replay button present, click replays.

4. **Sensor history details modal.** Open the per-event details modal for a sensor history entry with a video. Replay button present, click replays.

5. **Entity video sensor history page.** Open the full video event browser. The current event has the replay button. Critically: the `onerror`-driven "Video No Longer Available" fallback still works for genuine load failures (this template's inline handler was preserved), but is no longer falsely triggered by the replay action.

6. **Live camera view.** The thermostat / camera entity status modal renders the live camera. Confirm NO replay button appears there — live streams aren't replayable.

7. **Touch tablet.** Verify the replay button is comfortably tappable (the hit area extends past the visible 32px icon). Tap shows clear visual feedback (button darkens and shrinks slightly). No iOS save-image popover appears on long-press. No 300ms tap delay.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [ ] Unit tests added or updated if necessary. — Manual verification across the 5 contexts; the JS handler is a single 10-line delegated callback that's tested by exercising the UX.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

None.

---

## Screenshots (if applicable)

Available on request — the visible change is a small circular replay icon in the top-right corner of each event-video frame.

---

## Additional Notes

**Not addressed in this PR (deeper optimization, separate ticket worthy):**
- Videos in collapsed Bootstrap sections still fetch on initial render even though the user hasn't seen them yet. The replay button works around the UX symptom, but the wasted bandwidth and connection-pool usage remain. A future change could defer the `src` until the section is expanded (or use `loading="lazy"` if MJPEG honors it), eliminating the wasted fetches entirely.

**Out of scope / pre-existing:**
- The entity video sensor history template's inline `onerror` handler is preserved as-is. Lifting it to JS event delegation on the marker would be a small cleanup, but isn't required for this work and would add scope.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra

