### PR TITLE
Fix ZM simulator event_id collision across monitors

### DIFF
--- a/src/hi/simulator/services/zoneminder/zm_event_history.py
+++ b/src/hi/simulator/services/zoneminder/zm_event_history.py
@@ -1,6 +1,6 @@
 from collections import deque
 from datetime import datetime
-from typing import List
+from typing import Callable, List
 
 import hi.apps.common.datetimeproxy as datetimeproxy
 
@@ -9,10 +9,12 @@ from .sim_models import ZmSimEvent, ZmSimMonitor
 
 class ZmSimEventHistory:
 
-    event_counter = 0
-    
-    def __init__( self, zm_sim_monitor : ZmSimMonitor, max_events: int = 500 ):
+    def __init__( self,
+                  zm_sim_monitor      : ZmSimMonitor,
+                  event_id_allocator  : Callable[[], int],
+                  max_events          : int = 500 ):
         self._zm_sim_monitor = zm_sim_monitor
+        self._event_id_allocator = event_id_allocator
         self._zm_sim_events = deque( maxlen = max_events )
         return
 
@@ -38,13 +40,13 @@ class ZmSimEventHistory:
         return latest_zm_sim_event
 
     def add_zm_sim_event( self ) -> ZmSimEvent:
-        self.event_counter += 1
+        event_id = self._event_id_allocator()
         zm_sim_event = ZmSimEvent(
             zm_sim_monitor = self._zm_sim_monitor,
-            event_id = self.event_counter,
+            event_id = event_id,
             start_datetime = datetimeproxy.now(),
             end_datetime = None,
-            name = f'Event {self.event_counter}',
+            name = f'Event {event_id}',
         )
         self._zm_sim_events.append( zm_sim_event )
         return zm_sim_event

--- a/src/hi/simulator/services/zoneminder/zm_event_manager.py
+++ b/src/hi/simulator/services/zoneminder/zm_event_manager.py
@@ -13,7 +13,15 @@ class ZmSimEventManager( Singleton ):
     def __init_singleton__( self ):
         self._zm_sim_events_map : Dict[ int, ZmSimEventHistory ] = dict()
         self._data_lock = threading.Lock()
+        # ZM's wire event_id space is a single non-decreasing counter
+        # across all monitors. Centralizing allocation here keeps ids
+        # unique under simultaneous events on different monitors.
+        self._next_event_id = 0
         return
+
+    def _allocate_event_id( self ) -> int:
+        self._next_event_id += 1
+        return self._next_event_id
 
     def add_motion_value( self,
                           zm_sim_monitor : ZmSimMonitor,
@@ -23,6 +31,7 @@ class ZmSimEventManager( Singleton ):
             if monitor_id not in self._zm_sim_events_map:
                 self._zm_sim_events_map[monitor_id] = ZmSimEventHistory(
                     zm_sim_monitor = zm_sim_monitor,
+                    event_id_allocator = self._allocate_event_id,
                 )
             self._zm_sim_events_map[monitor_id].add_motion_value( motion_value = motion_value )
         return


### PR DESCRIPTION
## Pull Request: Fix ZM simulator event_id collision across monitors

### Issue Link
_No issue — small simulator-only fix; details below._

---

## Category
- [ ] **Feature** (New functionality)
- [x] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

**Symptom (observed in dev).** When two ZM monitors had active events at
the same time, HI sometimes attributed an event to the wrong camera.
Non-overlapping events were correct.

**Root cause.** `ZmSimEventHistory` (in the simulator, not production
ZM) declared its event counter as a *class* attribute:

```python
class ZmSimEventHistory:
    event_counter = 0
    ...
    def add_zm_sim_event(self):
        self.event_counter += 1   # shadows class attr with an
                                  # instance attr on first call
        event_id = self.event_counter
```

`self.event_counter += 1` desugars to `self.event_counter =
self.event_counter + 1` — the read finds the class attribute (0), but
the write creates a brand-new *instance* attribute. From that point
forward each `ZmSimEventHistory` (one per monitor) had its own counter
starting at 1, independent of every other monitor. Two monitors
therefore both emitted events with `Id=1`, then `Id=2`, etc.

The collision was invisible most of the time because non-overlapping
events closed on HI's side before the next monitor's collision arrived.
With **simultaneous** events on different monitors, HI saw two distinct
events sharing an `Id` and the second write overwrote the first's
monitor association — the operator saw an event tagged to the wrong
camera.

A secondary blast-radius site:
`ZmSimEventManager.find_event_by_id` walks monitor histories in
dict-insertion order and returns the first event matching the id. The
media endpoints (thumbnail / MJPEG playback) call this; with colliding
ids a thumbnail request could return a frame from the wrong monitor.

**Fix.** ZoneMinder's wire `event_id` space is a single non-decreasing
counter across all monitors, so allocation belongs on the singleton:

- `ZmSimEventManager` gains `_next_event_id` and `_allocate_event_id()`.
- `ZmSimEventHistory.__init__` now takes an `event_id_allocator:
  Callable[[], int]` and invokes it once per new event.
- Allocation runs under the existing `_data_lock` already held by
  `add_motion_value`, so concurrent motion callbacks on different
  monitors still get distinct ids.

The class-attribute footgun is gone, and the simulator now matches ZM's
real id semantics.

## How to Test

1. Configure two ZM simulator monitors.
2. Trigger overlapping motion: start motion on monitor A, then start
   motion on monitor B before A's event closes.
3. In HI, confirm both events appear and each is attributed to its
   correct camera (previously: A's event would re-attribute to B, or
   vice versa, once the second event arrived).
4. Verify event thumbnails / playback render frames from the correct
   monitor.
5. Test suite:
   ```bash
   make test    # 2955 tests, all passing
   make lint    # clean
   ```

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

---

## Screenshots (if applicable)

---

## Additional Notes

Simulator-only — production ZoneMinder already issues globally unique
event ids, so deployments against real ZM were never affected. The bug
was only observable through the simulator.

No new tests added; the existing simulator test surface doesn't exercise
the multi-monitor concurrency path and a meaningful test for this case
would mostly assert that allocation lives on the singleton rather than
the per-monitor history. Happy to add a small targeted test if desired.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**
@cassandra
