### PR TITLE
Conform existing state panels to ROW/TILE size budgets

### DIFF
--- a/docs/dev/frontend/entity-state-panels.md
+++ b/docs/dev/frontend/entity-state-panels.md
@@ -144,15 +144,11 @@ CollectionView consumes the panel framework through four `CollectionViewType` va
 
 ### Whole-card click contract
 
-In every CollectionView mode, the entire card is the click target — wrapped in an `<a>` to the status modal. **Controllers within a card must consume their own clicks** so taps on a slider / checkbox / button don't bubble to the wrapping `<a>` and trigger the modal:
+In every CollectionView mode, the entire card is the click target — wrapped in a `<div data-async data-href>` that routes to the status modal. Interactive descendants (`<a>`, `<button>`, `<input>`, `<select>`, `<textarea>`, `[role="button"]`) handle their own clicks; the antinode async-click handler skips the outer card action when the click originated inside an interactive descendant. Panel authors do not need to call `stopPropagation` on controller handlers — antinode bows out automatically.
 
-- **JS handlers**: call `event.stopPropagation()` (and `preventDefault()` where relevant) inside controller click / change handlers.
-- **CSS**: nothing special — `<input>` / `<button>` elements stop click propagation naturally on most browsers, but explicit `stopPropagation` in handlers is the safer guarantee.
-- **Touch-target sizing**: controllers must be **≥44pt** on the smallest side (Apple HIG; ~48dp Material) so finger taps land squarely on the controller and not the background card.
+The remaining panel-author concern is **touch-target sizing**: controllers should be **≥44pt** on the smallest side (Apple HIG; ~48dp Material). Below that, accidental background-card taps when targeting a controller become uncomfortable.
 
-Panels with controllers in their ROW / TILE templates carry the responsibility for both. Panels without controllers (smoke detector, plain camera) have no extra work — every card-pixel routes to the modal.
-
-Edit mode overrides all of this: when `request.view_parameters.is_editing` is set, JS intercepts card clicks and opens the entity edit pane regardless of the wrapper `<a>`'s `href`. This behavior is owned by the collection app, not by panels.
+In edit mode, all of this is overridden — a CSS rule (`[hi-edit="True"] .entity-card * { pointer-events: none }`) blocks descendant interactivity so card clicks always reach the wrapper and open the entity edit pane. Panel authors do not need to gate their handlers on edit state either; the CSS layer takes care of it.
 
 ## Template authoring
 
@@ -284,6 +280,6 @@ Read the existing panels when starting a new one — copy from the closest match
 - **Don't render extras inside the panel.** The modal context auto-appends an "Other states" section for any role outside the panel's declared set. Panels that try to render unknown states inside their own chrome will duplicate them.
 - **Declare what you display, display what you declare.** If a role appears in `required_roles` or `optional_roles`, the template must render it (subject to `{% if %}` for optionals). If a role is rendered but not declared, the framework will still treat it as an "extra" and may surface it twice in modal.
 - **Don't branch a template by `DisplayContext`.** If the panel needs context-specific layout, split into separate declarations with their own templates rather than `{% if context == ... %}` inside one file.
-- **Controllers must stop click propagation.** CollectionView wraps every card in an `<a>` to the entity modal. Sliders / checkboxes / buttons in ROW or TILE templates need to call `event.stopPropagation()` in their handlers (and meet the ≥44pt touch-target rule) so taps don't accidentally trigger the modal.
+- **Touch-target sizing for inner controllers.** CollectionView's whole-card click target opens the modal; antinode already skips that handler when the click came from an interactive descendant, so panel authors do not need to call `stopPropagation` themselves. The remaining concern is touch-target size — keep controllers ≥44pt so finger taps don't routinely land on the background card by accident.
 - **Don't author for `DEFAULT` CollectionViewType.** DEFAULT collections skip the panel framework entirely — they render icon + name through the collection wrapper, not through any panel template. Panels are dispatched only for GRID, LIST, and SECURITY view types.
 - **Shared partials live where they were first authored.** The flat state list and per-state row templates live under `state_panels/fallback/` (where they were born). Other panels that want the same list reference them from that path; there's no separate "shared" namespace.

--- a/docs/dev/frontend/entity-state-panels.md
+++ b/docs/dev/frontend/entity-state-panels.md
@@ -99,28 +99,19 @@ Extras — roles on the entity outside the panel's declared set — are framewor
 
 The framework defines three `DisplayContext` values. They name **shape** — the per-author design budget — not consumer layout. CollectionView and other consumers map their own layout choices to these contexts; the panel author thinks in shape budgets and authors a template per context the panel chooses to handle.
 
-| `DisplayContext` | Shape | Design budget | Extras behavior |
-|---|---|---|---|
-| `MODAL` | Roomy, unbounded height | ~480–640px wide, height grows with content | Framework auto-appends an expandable **"Other states"** section below the panel chrome whenever extras exist; renders each extra row using fallback `state_row.html`. |
-| `TILE`  | Square-ish, gridable | 240–280 wide × 200–260 tall target; 200 × 200 min; ~320 max wide; aspect 1:1 to 5:4 | Framework ignores extras silently. |
-| `ROW`   | Wide, single horizontal strip | full container width × ~80px tall target; 56 min / 128 max height; aspect ≥ 4:1 | Framework ignores extras silently. |
+| `DisplayContext` | Shape | Budget (CSS variables) | Aspect | Extras behavior |
+|---|---|---|---|---|
+| `MODAL` | Roomy, unbounded height | content-driven; modal container is ~480–640px wide | n/a | Framework auto-appends an expandable **"Other states"** section below the panel chrome whenever extras exist; renders each extra row using fallback `state_row.html`. |
+| `TILE`  | Square-ish, gridable | `--hi-panel-tile-*` in `src/hi/static/css/main.css` | 1:1 to 5:4 | Framework ignores extras silently. |
+| `ROW`   | Wide, single horizontal strip | `--hi-panel-row-*` in `src/hi/static/css/main.css` | ≥ 4:1 | Framework ignores extras silently. |
+
+The "Budget" column references the CSS variables that define concrete min / target / max sizes per context. The CSS is the source of truth; this guide deliberately does not reproduce the numbers to avoid drift. The qualitative shape and aspect-ratio contracts here are the conceptual budget every panel honors regardless of the specific numbers.
 
 Modal-context invariant: **every `EntityState` on an entity is reachable in the modal view, always.** Either the active panel handles it (declared role) or the framework surfaces it (extra). Authors cannot opt out.
 
 TILE and ROW are compact-by-intent; extras are intentionally invisible there to keep card layouts tight. Users who want to see every state open the modal.
 
-### Size-budget CSS variables
-
-Budgets are documented and shared via CSS variables so panel CSS and wrapper layout reference the same numbers:
-
-```css
---hi-panel-tile-min-size: 200px;
---hi-panel-tile-target-size: 240px;
---hi-panel-tile-max-size: 320px;
---hi-panel-row-min-height: 56px;
---hi-panel-row-target-height: 80px;
---hi-panel-row-max-height: 128px;
-```
+The height side of the TILE budget is a target, not a clamp. Panels whose content has an intrinsic aspect (camera live feeds being the canonical case) may exceed the height target when the content demands it — the width budget and the min-size contract still apply, so the wrapper's adaptive column count remains predictable.
 
 **Enforcement is soft.** No `max-width` / `max-height` clamping by the framework. Panel authors who exceed budgets see content visibly cramped or sliding; the feedback loop is immediate. Wrappers use `auto-fit` + `minmax(var(--hi-panel-tile-min-size), 1fr)` for TILE grids and `flex-direction: column` for ROW lists — column count follows from container width without JS.
 

--- a/src/hi/apps/entity/templates/entity/panes/entity_status_svg_icon.html
+++ b/src/hi/apps/entity/templates/entity/panes/entity_status_svg_icon.html
@@ -1,0 +1,27 @@
+{# Standalone polling-aware entity SVG icon. Renders its own <svg>    #}
+{# wrapper (suitable for use anywhere in HTML, not just inside an    #}
+{# outer SVG canvas like LocationView) and includes the polling-     #}
+{# update hooks when a primary state is supplied:                    #}
+{#                                                                    #}
+{#   svg_icon_item       (required) - icon visuals + viewBox         #}
+{#   primary_state_data  (optional) - EntityStateDisplayData whose   #}
+{#                                    state_id / svg_status_style    #}
+{#                                    feed the polling attrs         #}
+{#                                                                    #}
+{# When ``primary_state_data`` is omitted (or None), this template   #}
+{# renders an icon with no polling attributes — equivalent to the    #}
+{# truly-display-only variant. Use ``entity_display_only_svg_icon``  #}
+{# directly when polling attributes should never be present (e.g.    #}
+{# legend or example renderings).                                     #}
+{#                                                                    #}
+{# The polling attributes live on an inner <g> rather than the       #}
+{# <svg> root so the icon participates in the project's existing    #}
+{# ``g[status="..."]`` CSS rules (main.css:720+), which were         #}
+{# authored against the LocationView's <g>-wrapped icons.            #}
+<svg class="hi-entity-status-svg-icon"
+     xmlns="http://www.w3.org/2000/svg"
+     viewBox="{{ svg_icon_item.bounding_box }}">
+  <g {% if primary_state_data %}data-state-id="{{ primary_state_data.entity_state.id }}" data-status status="{{ primary_state_data.svg_status_style.status_value }}"{% endif %}>
+    {% include svg_icon_item.template_name %}
+  </g>
+</svg>

--- a/src/hi/apps/entity/templates/entity/state_panels/camera/row.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/camera/row.html
@@ -1,20 +1,38 @@
+{% load humanize tz video_tags %}
 {# Aliases declared in panel.py (role_data_template_aliases):           #}
 {#   motion_data (optional).                                            #}
+{#                                                                      #}
+{# ROW context: thumbnail snapshot (when available) + entity name +    #}
+{# (optional) motion chip + (optional) "Motion N min ago" timestamp.   #}
+{# No live feed embed — a tiny stream is not useful, and the modal     #}
+{# carries the live feed. Card-wide click goes to the modal.           #}
 <div class="hi-state-panel-camera hi-state-panel-camera--row">
 
-  <div class="stream">
-    {% if entity.has_live_view %}
-      {% include "console/panes/entity_live_view_w_link.html" with entity=entity %}
+  {% if entity.has_video_snapshot %}
+    {% entity_video_snapshot entity as snapshot %}
+    {% if snapshot and snapshot.source_url %}
+      {% cache_bust_url snapshot.source_url as snapshot_url %}
+      <div class="row-thumb">
+        <img src="{{ snapshot_url }}" alt="{{ entity.name }}">
+      </div>
     {% else %}
-      <div class="stream-unavailable">Offline</div>
+      <div class="row-icon">
+        {% include "entity/panes/entity_display_only_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item %}
+      </div>
     {% endif %}
-    {% if motion_data %}
-      {% include "entity/state_panels/camera/motion_chip.html" %}
-    {% endif %}
-  </div>
+  {% else %}
+    <div class="row-icon">
+      {% include "entity/panes/entity_display_only_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item %}
+    </div>
+  {% endif %}
 
-  <div class="row-meta">
-    <div class="entity-name">{{ entity.name }}</div>
-  </div>
+  <div class="entity-name">{{ entity.name }}</div>
+
+  {% if motion_data %}
+    {% include "entity/state_panels/camera/motion_chip.html" %}
+    {% with summary=motion_data.recent_state_value_summary %}{% if summary.penultimate %}
+      <div class="last-event">Motion {{ summary.penultimate.timestamp|localtime|naturaltime }}</div>
+    {% endif %}{% endwith %}
+  {% endif %}
 
 </div>

--- a/src/hi/apps/entity/templates/entity/state_panels/fallback/row.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/fallback/row.html
@@ -1,14 +1,16 @@
-{# Framework fallback for the ROW context. Renders the entity's icon  #}
-{# and name, plus the per-state row list when states exist. Self-     #}
-{# contained so stateless entities still surface their identity.     #}
+{# Framework fallback for the ROW context. Renders entity icon + name #}
+{# + the first few states (compact label/value or controller). Cap is #}
+{# applied via the |slice filter below — change ":3" to ":2" or ":4"  #}
+{# to tune the visible-state count uniformly. Entities with more      #}
+{# states than the cap show only the first N (sorted per the          #}
+{# framework's ENTITY_STATUS_VIEW_ORDERING role priority); the modal   #}
+{# carries the full state list.                                        #}
 <div class="hi-state-panel-fallback hi-state-panel-fallback--row">
   <div class="hi-state-panel-fallback__icon">
-    {% include "entity/panes/entity_display_only_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item %}
+    {% include "entity/panes/entity_status_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item primary_state_data=state_status_data_list|first %}
   </div>
-  <div class="hi-state-panel-fallback__body">
-    <div class="hi-state-panel-fallback__name">{{ entity.name }}</div>
-    {% if state_status_data_list %}
-      {% include "entity/state_panels/fallback/state_list.html" with entity_state_status_data_list=state_status_data_list %}
-    {% endif %}
-  </div>
+  <div class="hi-state-panel-fallback__name">{{ entity.name }}</div>
+  {% for state_data in state_status_data_list|slice:":3" %}
+    {% include "entity/state_panels/fallback/state_compact.html" with state_data=state_data %}
+  {% endfor %}
 </div>

--- a/src/hi/apps/entity/templates/entity/state_panels/fallback/state_compact.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/fallback/state_compact.html
@@ -1,0 +1,17 @@
+{# Per-state compact rendering for fallback ROW / TILE contexts.       #}
+{# Label above value/controller widget. Used by fallback row.html and #}
+{# tile.html, capped to a small number of states per the framework's  #}
+{# "fallback is intentionally minimal" stance.                        #}
+<div class="state-compact">
+  <div class="state-compact__label">{{ state_data.entity_state.short_name }}</div>
+  <div class="state-compact__value">
+    {% if state_data.controller_data_list %}
+      {% for controller_data in state_data.controller_data_list %}
+        {% include "control/panes/controller_data.html" with controller_data=controller_data %}
+      {% endfor %}
+    {% elif state_data.latest_display_label %}
+      <span data-state-id="{{ state_data.entity_state.id }}"
+            data-display-text>{{ state_data.latest_display_label }}</span>
+    {% endif %}
+  </div>
+</div>

--- a/src/hi/apps/entity/templates/entity/state_panels/fallback/tile.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/fallback/tile.html
@@ -1,12 +1,16 @@
-{# Framework fallback for the TILE context. Renders the entity's icon #}
-{# and name, plus the per-state row list when states exist. Self-     #}
-{# contained so stateless entities still surface their identity.     #}
+{# Framework fallback for the TILE context. Renders entity icon + name #}
+{# + the first few states (compact label/value or controller). Cap is  #}
+{# applied via the |slice filter below — change ":3" to ":2" or ":4"   #}
+{# to tune the visible-state count uniformly. Entities with more       #}
+{# states than the cap show only the first N (sorted per the           #}
+{# framework's ENTITY_STATUS_VIEW_ORDERING role priority); the modal    #}
+{# carries the full state list.                                         #}
 <div class="hi-state-panel-fallback hi-state-panel-fallback--tile">
   <div class="hi-state-panel-fallback__icon">
-    {% include "entity/panes/entity_display_only_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item %}
+    {% include "entity/panes/entity_status_svg_icon.html" with svg_icon_item=entity_status_data.display_only_svg_icon_item primary_state_data=state_status_data_list|first %}
   </div>
   <div class="hi-state-panel-fallback__name">{{ entity.name }}</div>
-  {% if state_status_data_list %}
-    {% include "entity/state_panels/fallback/state_list.html" with entity_state_status_data_list=state_status_data_list %}
-  {% endif %}
+  {% for state_data in state_status_data_list|slice:":2" %}
+    {% include "entity/state_panels/fallback/state_compact.html" with state_data=state_data %}
+  {% endfor %}
 </div>

--- a/src/hi/apps/entity/templates/entity/state_panels/smoke_detector/row.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/smoke_detector/row.html
@@ -1,6 +1,12 @@
 {% load humanize tz %}
 {# Aliases declared in panel.py (role_data_template_aliases):           #}
 {#   smoke_data, battery_data.                                          #}
+{#                                                                      #}
+{# ROW context: horizontal strip. Badge + name + status label +         #}
+{# (optional) "Triggered X ago" timestamp + (optional) battery readout, #}
+{# all on a single line. Status labels and last-event visibility are    #}
+{# driven by the panel-root ``status`` attribute (the decay-aware       #}
+{# token) per CSS rules that this template does not need to repeat.     #}
 <div class="hi-state-panel-smoke_detector hi-state-panel-smoke_detector--row"
      data-state-id="{{ smoke_data.entity_state.id }}"
      data-status
@@ -8,24 +14,24 @@
 
   {% include "entity/state_panels/smoke_detector/badge.html" %}
 
-  <div class="row-meta">
-    <div class="entity-name">{{ entity.name }}</div>
-    <div class="status-label status-label--idle">All Clear</div>
-    <div class="status-label status-label--active">Smoke Detected</div>
-    <div class="status-label status-label--recent">Recently Cleared</div>
-    <div class="status-label status-label--past">Past Alarm</div>
-    {% with summary=smoke_data.recent_state_value_summary %}{% if summary.penultimate %}
+  <div class="entity-name">{{ entity.name }}</div>
+
+  <div class="status-label status-label--idle">All Clear</div>
+  <div class="status-label status-label--active">Smoke Detected</div>
+  <div class="status-label status-label--recent">Recently Cleared</div>
+  <div class="status-label status-label--past">Past Alarm</div>
+
+  {% with summary=smoke_data.recent_state_value_summary %}{% if summary.penultimate %}
     <div class="last-event">Triggered {{ summary.penultimate.timestamp|localtime|naturaltime }}</div>
-    {% endif %}{% endwith %}
-  </div>
+  {% endif %}{% endwith %}
 
   {% if battery_data %}
-  <div class="aux-bits">
-    <span data-state-id="{{ battery_data.entity_state.id }}"
-          data-display-text
-          data-status
-          status="{{ battery_data.svg_status_style.status_value }}">{{ battery_data.latest_display_label }}</span>
-  </div>
+    <div class="aux-bits">
+      <span data-state-id="{{ battery_data.entity_state.id }}"
+            data-display-text
+            data-status
+            status="{{ battery_data.svg_status_style.status_value }}">{{ battery_data.latest_display_label }}</span>
+    </div>
   {% endif %}
 
 </div>

--- a/src/hi/apps/entity/templates/entity/state_panels/thermostat/row.html
+++ b/src/hi/apps/entity/templates/entity/state_panels/thermostat/row.html
@@ -1,67 +1,63 @@
 {# Aliases declared in panel.py (role_data_template_aliases):           #}
 {#   current_data, target_data, low_data, high_data,                    #}
-{#   action_data, mode_data, humidity_data.                             #}
+{#   action_data, mode_data, fan_data, preset_data.                     #}
+{#                                                                      #}
+{# ROW context: horizontal strip showing name + current temp + setpoint #}
+{# stepper(s) + optional mode / fan / preset selects across the row.    #}
+{# No SVG dial in this context — the modal carries the dial. Setpoint   #}
+{# steppers are interactive; click handlers in thermostat.js call       #}
+{# stopPropagation so taps don't trigger the surrounding card-wrapper   #}
+{# modal-open click.                                                    #}
 <div class="hi-state-panel-thermostat hi-state-panel-thermostat--row"
      {% if action_data %}data-state-id="{{ action_data.entity_state.id }}" data-status status="{{ action_data.latest_sensor_value }}"{% endif %}
      {% if mode_data %}data-hvac-mode-state-id="{{ mode_data.entity_state.id }}" data-hvac-mode="{{ mode_data.latest_sensor_value }}"{% endif %}>
 
-  <div class="dial">
-    <svg class="dial-svg" viewBox="0 0 220 220" aria-hidden="true">
-      <circle class="dial-track" cx="110" cy="110" r="95" fill="none" stroke-width="2"/>
-
-      {% if low_data and high_data %}
-        <g class="dial-setpoint-marker dial-setpoint-marker--dual dial-setpoint-marker--low"
-           data-marker-state-id="{{ low_data.entity_state.id }}"
-           data-temp-value="{{ low_data.latest_display_value.magnitude }}">
-          <line x1="110" y1="10" x2="110" y2="24" stroke-width="6" stroke-linecap="round"/>
-        </g>
-        <g class="dial-setpoint-marker dial-setpoint-marker--dual dial-setpoint-marker--high"
-           data-marker-state-id="{{ high_data.entity_state.id }}"
-           data-temp-value="{{ high_data.latest_display_value.magnitude }}">
-          <line x1="110" y1="10" x2="110" y2="24" stroke-width="6" stroke-linecap="round"/>
-        </g>
-      {% endif %}
-      {% if target_data %}
-        <g class="dial-setpoint-marker dial-setpoint-marker--single"
-           data-marker-state-id="{{ target_data.entity_state.id }}"
-           data-temp-value="{{ target_data.latest_display_value.magnitude }}">
-          <line x1="110" y1="10" x2="110" y2="24" stroke-width="6" stroke-linecap="round"/>
-        </g>
-      {% endif %}
-
-      <g class="dial-current-marker"
-         data-marker-state-id="{{ current_data.entity_state.id }}"
-         data-temp-value="{{ current_data.latest_display_value.magnitude }}">
-        <circle cx="110" cy="17" r="9"/>
-      </g>
-    </svg>
-    <div class="dial-center">
-      <span class="dial-temp"
-            data-state-id="{{ current_data.entity_state.id }}"
-            data-display-text>{{ current_data.latest_display_label }}</span>
+  <div class="row-identity">
+    <div class="entity-name">{{ entity.name }}</div>
+    {% if action_data %}
+    <div class="row-mode-status">
+      <span class="dial-mode-label" for-status="heating">Heating</span>
+      <span class="dial-mode-label" for-status="cooling">Cooling</span>
+      <span class="dial-mode-label" for-status="idle">Idle</span>
+      <span class="dial-mode-label" for-status="off">Off</span>
     </div>
+    {% endif %}
   </div>
 
-  <div class="row-meta">
-    <div class="entity-name">{{ entity.name }}</div>
+  <div class="row-current">
+    <span class="row-current-temp"
+          data-state-id="{{ current_data.entity_state.id }}"
+          data-display-text>{{ current_data.latest_display_label }}</span>
+  </div>
+
+  <div class="row-setpoints">
     {% if low_data and high_data %}
-      <div class="setpoint-summary setpoint-summary--dual">
-        <strong data-state-id="{{ low_data.entity_state.id }}" data-display-text>{{ low_data.latest_display_label }}</strong>
-        –
-        <strong data-state-id="{{ high_data.entity_state.id }}" data-display-text>{{ high_data.latest_display_label }}</strong>
+      <div class="setpoint-block setpoint-block--dual">
+        {% include "entity/state_panels/thermostat/setpoint_stepper.html" with setpoint_data=low_data %}
+        {% include "entity/state_panels/thermostat/setpoint_stepper.html" with setpoint_data=high_data %}
       </div>
     {% endif %}
     {% if target_data %}
-      <div class="setpoint-summary setpoint-summary--single">
-        Target <strong data-state-id="{{ target_data.entity_state.id }}" data-display-text>{{ target_data.latest_display_label }}</strong>
-      </div>
-    {% endif %}
-    {% if humidity_data %}
-      <div class="humidity-line">
-        Humidity <span data-state-id="{{ humidity_data.entity_state.id }}"
-                       data-display-text>{{ humidity_data.latest_display_label }}</span>
+      <div class="setpoint-block setpoint-block--single">
+        {% include "entity/state_panels/thermostat/setpoint_stepper.html" with setpoint_data=target_data %}
       </div>
     {% endif %}
   </div>
+
+  {% if mode_data %}
+  <div class="row-control row-control--mode">
+    {% include "entity/state_panels/thermostat/role_control.html" with role_data=mode_data %}
+  </div>
+  {% endif %}
+  {% if fan_data %}
+  <div class="row-control row-control--fan">
+    {% include "entity/state_panels/thermostat/role_control.html" with role_data=fan_data %}
+  </div>
+  {% endif %}
+  {% if preset_data %}
+  <div class="row-control row-control--preset">
+    {% include "entity/state_panels/thermostat/role_control.html" with role_data=preset_data %}
+  </div>
+  {% endif %}
 
 </div>

--- a/src/hi/static/css/main.css
+++ b/src/hi/static/css/main.css
@@ -1768,6 +1768,12 @@ g[hover] {
     flex-direction: column;
     gap: 8px;
     margin-bottom: 1rem;
+    /* Establish a container query context so ROW-context panels can
+       use @container to adapt to actual content width (immune to
+       sidebar / layout-chrome width that @media viewport queries
+       cannot account for). */
+    container-type: inline-size;
+    container-name: collection-row;
 }
 
 /* ================================================================ */

--- a/src/hi/static/css/main.css
+++ b/src/hi/static/css/main.css
@@ -1821,10 +1821,16 @@ g[hover] {
 }
 
 .entity-card--tile {
+    /* display: grid so the single panel child auto-stretches to fill
+     * both axes — min-height alone wouldn't give the panel's height:100%
+     * a resolvable parent height, leaving the card's white background
+     * visible below the panel content. */
+    display: grid;
     min-height: var(--hi-panel-tile-min-size);
 }
 
 .entity-card--row {
+    display: grid;
     min-height: var(--hi-panel-row-min-height);
 }
 

--- a/src/hi/static/js/antinode.js
+++ b/src/hi/static/js/antinode.js
@@ -442,8 +442,13 @@ function asyncClickHandler(event) {
     // interactive descendant of ``this``. (When ``this`` IS the
     // interactive element — the normal ``<a data-async>`` case —
     // closest() returns the anchor itself and we proceed.)
+    //
+    // ``label`` is included because label-wrapped form controls
+    // (e.g. the on/off switch's <label class=switch-modern> wrapping
+    // a checkbox + styled <span>) take user clicks on the visible
+    // <span> child, which has no other interactive ancestor.
     let $interactive = $(event.target).closest(
-        'a, button, input, select, textarea, [role="button"]'
+        'a, button, input, select, textarea, label, [role="button"]'
     );
     if ( $interactive.length
          && $interactive[0] !== this

--- a/src/hi/static/js/antinode.js
+++ b/src/hi/static/js/antinode.js
@@ -433,10 +433,26 @@ function asyncSubmitHandlerHelper( $form ) {
 // trigger an ansynchonous (aka, ajax) request.
 //
 function asyncClickHandler(event) {
+    let $anchor = $(this);
+
+    // When a ``<div data-async>`` is used as a card-wide click target,
+    // it may contain interactive descendants (inner antinode links,
+    // controllers, selects) that should handle their own clicks. Skip
+    // the outer handler when the click originated inside such an
+    // interactive descendant of ``this``. (When ``this`` IS the
+    // interactive element — the normal ``<a data-async>`` case —
+    // closest() returns the anchor itself and we proceed.)
+    let $interactive = $(event.target).closest(
+        'a, button, input, select, textarea, [role="button"]'
+    );
+    if ( $interactive.length
+         && $interactive[0] !== this
+         && $.contains( this, $interactive[0] ) ) {
+        return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
-
-    let $anchor = $(this);
 
     handleHideShowIfNeeded( $anchor );
 

--- a/src/hi/static/state_panels/camera/camera.css
+++ b/src/hi/static/state_panels/camera/camera.css
@@ -81,19 +81,55 @@
 /* List card layout                                               */
 /* ============================================================== */
 
+/* ROW context: status-only horizontal strip — no live feed embed.    */
+/* A small snapshot thumbnail (when available) replaces the stream    */
+/* for visual identification; falls back to the entity icon when no   */
+/* snapshot exists.                                                    */
+
 .hi-state-panel-camera--row {
-    display: grid;
-    grid-template-columns: 160px 1fr;
-    gap: 12px;
+    display: flex;
     align-items: center;
+    gap: 12px;
+    padding: 6px 12px;
+    min-height: var(--hi-panel-row-min-height);
 }
-.hi-state-panel-camera--row .stream {
-    width: 160px;
+.hi-state-panel-camera--row .row-thumb {
+    flex-shrink: 0;
+    width: 80px;
     aspect-ratio: 16 / 9;
+    background: #000;
+    border-radius: 3px;
+    overflow: hidden;
 }
-.hi-state-panel-camera--row .row-meta { min-width: 0; }
+.hi-state-panel-camera--row .row-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.hi-state-panel-camera--row .row-icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+}
+.hi-state-panel-camera--row .row-icon svg {
+    width: 100%;
+    height: 100%;
+}
 .hi-state-panel-camera--row .entity-name {
-    font-size: 13px; font-weight: 600; line-height: 1.2;
+    flex: 0 1 auto;
+    min-width: 0;
+    font-size: 14px; font-weight: 600; line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.hi-state-panel-camera--row .last-event {
+    font-size: 11px;
+    line-height: 1.2;
+    color: var(--text-muted, #6c757d);
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 /* ============================================================== */
@@ -180,4 +216,14 @@
     height: 24px;
     top: 4px;
     right: 4px;
+}
+
+/* In ROW context the chip flows inline (no stream to overlay) — */
+/* drop the absolute positioning and the box-shadow.             */
+.hi-state-panel-camera--row .motion-chip {
+    position: static;
+    flex-shrink: 0;
+    box-shadow: none;
+    top: auto;
+    right: auto;
 }

--- a/src/hi/static/state_panels/fallback/fallback.css
+++ b/src/hi/static/state_panels/fallback/fallback.css
@@ -1,11 +1,10 @@
 /* Framework fallback panel for ROW and TILE contexts. Renders entity
- * icon + name plus an optional state list — self-contained so the
- * collection-card wrapper does not need to add any chrome of its own.
+ * icon + name plus a compact list of the first few states (controllers
+ * + sensor values). Self-contained — the collection-card wrapper does
+ * not add any chrome of its own.
  */
 
 .hi-state-panel-fallback__icon {
-    width: 32px;
-    height: 32px;
     flex-shrink: 0;
 }
 .hi-state-panel-fallback__icon svg {
@@ -13,35 +12,75 @@
     height: 100%;
 }
 .hi-state-panel-fallback__name {
-    font-weight: 500;
+    font-weight: 600;
     color: var(--black);
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-/* ROW: icon left, body right (name above optional state list). */
-.hi-state-panel-fallback--row {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    padding: 8px 12px;
-    min-height: var(--hi-panel-row-min-height);
-}
-.hi-state-panel-fallback--row .hi-state-panel-fallback__body {
-    flex: 1;
-    min-width: 0;
-}
-.hi-state-panel-fallback--row .hi-state-panel-fallback__name {
-    margin-bottom: 4px;
     white-space: nowrap;
 }
 
-/* TILE: icon centered atop name; state list (when present) below. */
+/* Per-state compact block: label above value/control. Both contexts
+ * use the same per-state structure; the parent layout differs (the
+ * row stacks states horizontally, the tile stacks them vertically).
+ */
+.state-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.state-compact__label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted, #6c757d);
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.state-compact__value {
+    font-size: 13px;
+    line-height: 1.2;
+    overflow: hidden;
+}
+/* Compact form inside the value cell — strip the controller's default
+ * row chrome (history button, oversized text-center label) that lives
+ * in controller_data_row.html. The form widget itself stays
+ * functional. */
+.state-compact__value form {
+    margin: 0;
+}
+
+/* ROW: icon left, name next, states stacked horizontally on the right. */
+.hi-state-panel-fallback--row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 12px;
+    min-height: var(--hi-panel-row-min-height);
+}
+.hi-state-panel-fallback--row .hi-state-panel-fallback__icon {
+    width: 32px;
+    height: 32px;
+}
+.hi-state-panel-fallback--row .hi-state-panel-fallback__name {
+    flex: 0 1 auto;
+    min-width: 0;
+    font-size: 14px;
+}
+.hi-state-panel-fallback--row .state-compact {
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 280px;
+}
+
+/* TILE: icon centered atop name; states stacked vertically below. */
 .hi-state-panel-fallback--tile {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
     padding: 12px;
     text-align: center;
 }
@@ -52,4 +91,8 @@
 .hi-state-panel-fallback--tile .hi-state-panel-fallback__name {
     font-size: 13px;
     line-height: 1.2;
+}
+.hi-state-panel-fallback--tile .state-compact {
+    align-items: center;
+    width: 100%;
 }

--- a/src/hi/static/state_panels/smoke_detector/smoke_detector.css
+++ b/src/hi/static/state_panels/smoke_detector/smoke_detector.css
@@ -141,29 +141,47 @@
 .hi-state-panel-smoke_detector--modal .aux-value { font-size: 14px; font-weight: 500; }
 
 /* ============================================================== */
-/* List card layout                                               */
+/* Row card layout: badge + name + status + last-event + aux all     */
+/* on one horizontal line.                                            */
 /* ============================================================== */
 
 .hi-state-panel-smoke_detector--row {
-    display: grid;
-    grid-template-columns: 60px 1fr auto;
-    gap: 12px;
+    display: flex;
     align-items: center;
-    padding: 4px;
+    gap: 12px;
+    padding: 6px 12px;
+    min-height: var(--hi-panel-row-min-height);
 }
-.hi-state-panel-smoke_detector--row .badge { width: 60px; height: 60px; }
-.hi-state-panel-smoke_detector--row .row-meta { min-width: 0; }
+.hi-state-panel-smoke_detector--row .badge { width: 44px; height: 44px; flex-shrink: 0; }
 .hi-state-panel-smoke_detector--row .entity-name {
     font-size: 14px; font-weight: 600; line-height: 1.2;
+    flex: 0 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-.hi-state-panel-smoke_detector--row .status-label { font-size: 12px; }
+.hi-state-panel-smoke_detector--row .status-label {
+    font-size: 13px;
+    flex-shrink: 0;
+}
+/* margin-left: auto on both last-event and aux-bits pushes the      */
+/* right-most group to the right edge. Whichever of the two appears  */
+/* first consumes the available free space; the other sits flush     */
+/* next to it. Works for all combinations (either present, both      */
+/* present, neither present).                                         */
 .hi-state-panel-smoke_detector--row .last-event {
     font-size: 11px;
     line-height: 1.2;
+    color: var(--text-muted, #6c757d);
+    flex-shrink: 0;
+    margin-left: auto;
 }
 .hi-state-panel-smoke_detector--row .aux-bits {
     font-size: 11px;
     color: var(--text-muted, #6c757d);
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 /* ============================================================== */

--- a/src/hi/static/state_panels/smoke_detector/smoke_detector.css
+++ b/src/hi/static/state_panels/smoke_detector/smoke_detector.css
@@ -205,10 +205,14 @@
     line-height: 1.2;
     margin-top: 4px;
 }
-.hi-state-panel-smoke_detector--tile[status="idle"]   { background: var(--hi-smoke-idle-bg); }
-.hi-state-panel-smoke_detector--tile[status="active"] { background: var(--hi-smoke-active-bg); }
-.hi-state-panel-smoke_detector--tile[status="recent"] { background: var(--hi-smoke-recent-bg); }
-.hi-state-panel-smoke_detector--tile[status="past"]   { background: var(--hi-smoke-past-bg); }
+.hi-state-panel-smoke_detector--tile[status="idle"],
+.hi-state-panel-smoke_detector--row[status="idle"]   { background: var(--hi-smoke-idle-bg); }
+.hi-state-panel-smoke_detector--tile[status="active"],
+.hi-state-panel-smoke_detector--row[status="active"] { background: var(--hi-smoke-active-bg); }
+.hi-state-panel-smoke_detector--tile[status="recent"],
+.hi-state-panel-smoke_detector--row[status="recent"] { background: var(--hi-smoke-recent-bg); }
+.hi-state-panel-smoke_detector--tile[status="past"],
+.hi-state-panel-smoke_detector--row[status="past"]   { background: var(--hi-smoke-past-bg); }
 
 /* ============================================================== */
 /* Battery low-state escalation.                                  */

--- a/src/hi/static/state_panels/thermostat/thermostat.css
+++ b/src/hi/static/state_panels/thermostat/thermostat.css
@@ -116,7 +116,7 @@
 }
 .hi-state-panel-thermostat--modal .thermostat-modes-grid {
     display: grid;
-    tile-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     gap: 12px 16px;
 }
 .hi-state-panel-thermostat--modal .control-group {
@@ -150,13 +150,13 @@
     gap: 12px;
 }
 .hi-state-panel-thermostat .stepper-btn {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     border: 1px solid var(--line-color, #d0d7de);
     background: white;
     color: var(--primary-color, #177072);
-    font-size: 18px;
+    font-size: 22px;
     line-height: 1;
     cursor: pointer;
     display: inline-flex;
@@ -205,7 +205,7 @@
 
 .hi-state-panel-thermostat--row {
     display: grid;
-    tile-template-columns: 96px 1fr;
+    grid-template-columns: 96px 1fr;
     gap: 14px;
     align-items: center;
 }

--- a/src/hi/static/state_panels/thermostat/thermostat.css
+++ b/src/hi/static/state_panels/thermostat/thermostat.css
@@ -296,8 +296,10 @@
     padding: 8px;
     height: 100%;
 }
-.hi-state-panel-thermostat--tile[status="heating"] { background: var(--hi-thermo-heating-bg); }
-.hi-state-panel-thermostat--tile[status="cooling"] { background: var(--hi-thermo-cooling-bg); }
+.hi-state-panel-thermostat--tile[status="heating"],
+.hi-state-panel-thermostat--row[status="heating"] { background: var(--hi-thermo-heating-bg); }
+.hi-state-panel-thermostat--tile[status="cooling"],
+.hi-state-panel-thermostat--row[status="cooling"] { background: var(--hi-thermo-cooling-bg); }
 .hi-state-panel-thermostat--tile .tile-temp {
     font-size: 44px;
     font-weight: 300;

--- a/src/hi/static/state_panels/thermostat/thermostat.css
+++ b/src/hi/static/state_panels/thermostat/thermostat.css
@@ -204,25 +204,83 @@
 /* ============================================================== */
 
 .hi-state-panel-thermostat--row {
-    display: grid;
-    grid-template-columns: 96px 1fr;
-    gap: 14px;
+    display: flex;
     align-items: center;
+    gap: 16px;
+    padding: 8px 12px;
+    min-height: var(--hi-panel-row-min-height);
 }
-.hi-state-panel-thermostat--row .dial {
-    width: 96px;
-    height: 96px;
+.hi-state-panel-thermostat--row .row-identity {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
 }
-.hi-state-panel-thermostat--row .dial-temp { font-size: 26px; }
 .hi-state-panel-thermostat--row .entity-name {
     font-size: 14px; font-weight: 600; line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-.hi-state-panel-thermostat--row .setpoint-summary {
-    font-size: 12px; color: var(--text-muted, #6c757d); margin-top: 2px;
+.hi-state-panel-thermostat--row .row-mode-status {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-.hi-state-panel-thermostat--row .setpoint-summary strong { color: #1f2328; font-weight: 500; }
-.hi-state-panel-thermostat--row .humidity-line {
-    font-size: 11px; color: var(--text-muted, #6c757d); margin-top: 2px;
+.hi-state-panel-thermostat--row .row-current {
+    flex: 0 0 auto;
+}
+.hi-state-panel-thermostat--row .row-current-temp {
+    font-size: 40px;
+    font-weight: 300;
+    line-height: 1;
+}
+.hi-state-panel-thermostat--row[status="heating"] .row-current-temp {
+    color: var(--hi-thermo-heating-color);
+}
+.hi-state-panel-thermostat--row[status="cooling"] .row-current-temp {
+    color: var(--hi-thermo-cooling-color);
+}
+.hi-state-panel-thermostat--row .row-setpoints {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: flex-start;
+    gap: 16px;
+}
+.hi-state-panel-thermostat--row .setpoint-block--dual {
+    gap: 16px;
+}
+.hi-state-panel-thermostat--row .row-control {
+    flex: 0 1 auto;
+}
+.hi-state-panel-thermostat--row .row-control select {
+    font-size: 12px;
+    padding: 4px 6px;
+    max-width: 110px;
+}
+
+/* Progressive disclosure as the row narrows: hide the right-most,
+ * lower-priority controllers first. Mode select disappears before the
+ * mode-status label (which still conveys the mode visually). Below
+ * the last breakpoint, the absolute minimum (name + current + setpoint)
+ * remains. Container queries scope to the actual content width (set on
+ * .collection-row-list in main.css), independent of sidebar width.
+ */
+@container collection-row (max-width: 1100px) {
+    .hi-state-panel-thermostat--row .row-control--preset { display: none; }
+}
+@container collection-row (max-width: 900px) {
+    .hi-state-panel-thermostat--row .row-control--fan { display: none; }
+}
+@container collection-row (max-width: 700px) {
+    .hi-state-panel-thermostat--row .row-control--mode { display: none; }
+}
+@container collection-row (max-width: 500px) {
+    .hi-state-panel-thermostat--row .row-mode-status { display: none; }
 }
 
 /* ============================================================== */


### PR DESCRIPTION
## Pull Request: Conform existing state panels to ROW/TILE size budgets

### Issue Link

Closes #342

---

## Category

- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [x] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Brings the three completed state panels (`thermostat`, `smoke_detector`, `camera`) and the framework fallback panel into conformance with the ROW/TILE size-budget contract introduced in #339. Prerequisite for #326 (per-EntityType panel roadmap) — until existing panels conformed, they couldn't be cited as exemplars by new-panel work.

Six commits, one per phase.

**Phase 1 — Stop-the-bleed + doc sync** (`b19e8be5`)
- Fixes two real CSS bugs in `thermostat.css` at lines 119 and 208 where `grid-template-columns` had been mangled to `tile-template-columns` by an over-eager #339 Phase 2 `grid-temp` → `tile-temp` `replace_all` (the substring match caught more than intended). Browsers silently dropped the unknown property, so the thermostat modal modes-grid and the thermostat row dial-meta grid have been rendering broken layouts since #339 merged.
- Framework guide (`docs/dev/frontend/entity-state-panels.md`) stops duplicating panel size-budget numbers. The doc now references the `--hi-panel-tile-*` / `--hi-panel-row-*` CSS variables in `main.css` as the source of truth, retains the qualitative shape and aspect-ratio contracts that aren't in the CSS, and adds a note that the height side of the TILE budget is a target rather than a clamp (camera live feeds being the canonical content-driven exception).
- Modal stepper buttons enlarged from 32×32 to 44×44 to meet the documented touch-target rule.

**Phase 2 — Thermostat ROW redesign with setpoint controls** (`0d6870a6`)
- Drops the 96×96 SVG dial from the row context (it blew the ~80px row height target). The dial is retained in modal and tile contexts.
- New horizontal-strip layout: entity name + mode-status label on the left, color-tinted current temperature (heating/cooling tint via panel-root `[status]` attribute), setpoint stepper(s) (single or dual), mode / fan / preset selects on the right.
- Steppers in the row are fully interactive (≥44pt touch targets).
- **Framework cleanup**: antinode's `div[data-async]` click handler now skips when the click originated inside an interactive descendant (`a, button, input, select, textarea, [role="button"]`). Previously, the wrapping card click handler fired before any panel-author `stopPropagation` could intervene, opening the modal on every controller interaction. This factoring also retires the "controllers must stop propagation" contract from the framework guide — panel authors no longer need to think about it; antinode bows out automatically when the click hit an inner control.
- **Container queries** for progressive disclosure: as the actual content width narrows, hide right-most lower-priority controllers (preset → fan → mode select → mode-status label). Container queries scope to `.collection-row-list`, not the viewport, so the breakpoints work regardless of sidebar / chrome width.

**Phase 3 — Smoke detector ROW horizontal-strip layout** (`35c1fdd9`)
- Flattens the prior 3-column-grid-with-vertical-meta-stack into a single horizontal flex row. Badge + entity name + status label + (optional) "Triggered N ago" timestamp + (optional) battery readout, all on one line.
- Badge sized down to 44×44 so the row fits the budget cleanly.

**Phase 4 — Camera ROW redesign without live feed** (`b4b69412`)
- Drops the 160×90 stream embed from the camera row context — a tiny live feed isn't useful, and the modal carries the full-size live view. Replaces with a status-only horizontal strip: 80×45 static snapshot thumbnail (or the camera entity icon when no snapshot is available), entity name, optional inline motion chip, optional "Motion N ago" timestamp.
- Motion chip CSS overridden in ROW context to flow inline rather than overlay-absolute (no stream to overlay).

**Phase 5 — Visual audit + polish** (`b17af5e3` and `81372d5b`)
- `.entity-card--tile` and `--row` become `display: grid` so the single panel-root child auto-stretches to fill the card. Previously `min-height` alone didn't establish a resolvable parent height for the panel's `height: 100%`, leaving the card's white background visible around colored panel content.
- Smoke detector and thermostat ROW templates carry the same status-tinted backgrounds as their TILE counterparts. Camera ROW intentionally has no tint — the snapshot is the visual.
- **Fallback ROW/TILE refactor**: the previous fallback row/tile rendered the full per-state list using `state_row.html` (Bootstrap `<div class="card"><div class="card-body">` chrome per state). Inside the new `.entity-card` wrapper, this produced card-within-card-within-card chrome, and entities with many states overflowed any compact container.
  - New compact layout: icon + name + first N state widgets (currently 3 in ROW, 2 in TILE; the bound is the `|slice:":N"` filter in the templates — easy to tune).
  - Per-state widget uses the existing `controller_data.html` directly (sliders, selects, on/off toggles all remain functional in compact contexts). Sense-only states fall back to `latest_display_label` text.
  - ROW state widgets use `flex: 1 1 0` with `max-width: 280px` so they grow to fill available row width rather than huddling on the right with whitespace before them.
- New `entity_status_svg_icon.html` template: standalone polling-hooked SVG icon. Renders its own `<svg>` wrapper plus an inner `<g status="..." data-status data-state-id="..."/>` that carries polling attributes. The `<g>`-wrap is deliberate so the icon participates in the project's existing `g[status="..."]` CSS rules in `main.css` (~line 720+), authored against LocationView's `<g>`-wrapped icons. Fallback row/tile pass the first state of `state_status_data_list` (role-priority primary) as the polling source. `entity_display_only_svg_icon.html` is left intact for legend / example renderings where polling attributes should never be present.
- Antinode interactive-descendant skip extended to include `<label>` — on/off toggle switches use `<label class=switch-modern>` wrapping a checkbox + styled `<span>`; the user clicks the visible span, which needs the wrapping label to be recognized as controller-targeted.

---

## How to Test

**Automated**
- `make test` — 2976 tests pass.
- `make lint` — clean.

**Manual (visual)** — each phase is independently verifiable; the full sweep is 3 panels × 3 contexts × 3+ CollectionViewTypes.

1. **Thermostat modal**: open from anywhere. Confirm Mode / Fan / Preset selects render in a 2-column grid (was broken pre-#342, stacked vertically). Setpoint stepper buttons feel touch-friendly (44×44).
2. **Thermostat in a LIST collection**: row uses horizontal width — name + mode label on the left, large color-tinted current temp, setpoint stepper(s), mode / fan / preset selects across the row. Resize the window — preset hides first (at ~1100px container width), then fan, then mode select, then mode-status label, in that order. Tap a setpoint stepper or a mode select → only that control acts; the card does NOT also open the modal.
3. **Thermostat in a GRID collection**: tile shows large current-temp + mode label + setpoint summary, tinted background fills the entire card to the border.
4. **Smoke detector** in MODAL / GRID / LIST: confirm decay states (idle / active / recent / past) all render with the right palette, status-tinted backgrounds fill the card, ROW is a single horizontal line with badge + name + status label + (Triggered N ago) + (battery).
5. **Camera** in MODAL / GRID / LIST: modal shows live feed, tile shows live feed filling the cell, **row shows a static snapshot thumbnail** (or camera icon if no snapshot) + name + motion chip inline + last-motion timestamp.
6. **Fallback (e.g. Zoo Color Bulb, which has 5 states)** in MODAL / GRID / LIST: modal shows full state list with the original chrome; tile and row show a compact set (2 and 3 respectively) of state widgets — sliders / selects / on/off toggles all work, modal does NOT open when interacting with them.
7. **Edit mode** across all panels: card click opens the entity edit pane regardless of which inner element was clicked.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

- Builds on #340 (#327: Complete the three initial EntityStatusPanel implementations).
- Builds on #341 (#339: CollectionView interaction-intent model + panel framework ROW/TILE rename).
- Unblocks #326 (EntityStatusPanel roadmap — per-EntityType panel candidates).

## Screenshots (if applicable)

N/A — visual verification path documented above.

## Additional Notes

- The framework's controller-stop-propagation contract has been retired. Panel authors no longer need to call `event.stopPropagation()` on inner controllers; antinode skips the outer card click when the click originated from an interactive descendant. The framework guide's pitfall entry has been updated accordingly.
- The framework guide now points at the CSS variables for budget numbers rather than duplicating them. Future budget tweaks happen in `main.css` only.
- Container queries (`@container`) are used for the thermostat ROW's progressive disclosure breakpoints. Browser support is ~93% per caniuse; should be fine for the project's audience.
- Touch-target rule (≥44pt minimum on controllers in compact contexts) remains as a soft panel-author contract — documented in the framework guide.

---

### **Ready for Review?**

- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
