### PR TITLE
Frigate: correct _reload_implementation health claims

### DIFF
--- a/src/hi/services/frigate/frigate_manager.py
+++ b/src/hi/services/frigate/frigate_manager.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional
 from asgiref.sync import sync_to_async
 
 from hi.apps.common.utils import str_to_bool
-from hi.apps.system.enums import ApiHealthStatusType
 
 from hi.apps.common.singleton_manager import SingletonManager
 from hi.apps.system.aggregate_health_provider import AggregateHealthProvider
@@ -89,10 +88,10 @@ class FrigateManager( SingletonManager, AggregateHealthProvider, ApiHealthStatus
                 integration_id = FrigateMetaData.integration_id,
             )
         except Integration.DoesNotExist:
-            self.update_api_health_status( ApiHealthStatusType.DISABLED )
+            self.record_disabled( 'Frigate integration disabled' )
             return
         if not integration.is_enabled:
-            self.update_api_health_status( ApiHealthStatusType.DISABLED )
+            self.record_disabled( 'Frigate integration disabled' )
             return
         integration_attributes = list( integration.attributes.all() )
         self._attribute_map = self._build_attribute_map(
@@ -104,9 +103,9 @@ class FrigateManager( SingletonManager, AggregateHealthProvider, ApiHealthStatus
             )
         except Exception:
             logger.exception( 'Failed to build Frigate client.' )
-            self.update_api_health_status( ApiHealthStatusType.UNAVAILABLE )
+            self.record_error( 'Failed to build Frigate client' )
             return
-        self.update_api_health_status( ApiHealthStatusType.HEALTHY )
+        self.record_healthy( 'Reloaded' )
         return
 
     @staticmethod

--- a/src/hi/services/frigate/tests/test_frigate_integration.py
+++ b/src/hi/services/frigate/tests/test_frigate_integration.py
@@ -18,7 +18,7 @@ from django.test import TestCase
 
 from hi.apps.entity.enums import EntityType
 from hi.apps.entity.models import Entity
-from hi.apps.system.enums import ApiHealthStatusType
+from hi.apps.system.enums import ApiHealthStatusType, HealthStatusType
 from hi.integrations.models import Integration
 
 from hi.apps.entity.enums import VideoStreamType
@@ -286,32 +286,36 @@ class TestFrigateGatewayVideoStream( TestCase ):
 
 
 class TestFrigateManagerHealthRecording( TestCase ):
-    """``FrigateManager._reload_implementation`` must record its own
-    API-health outcome on every reload. The manager registers itself
-    as an API health provider; without an explicit record_* call the
-    default UNKNOWN status leaks into the aggregate and the UI banner
-    shows WARNING even when the monitor is reporting Healthy.
-
-    Mirrors ``ZoneMinderManager._reload_implementation`` — same bug
-    pattern, same fix shape."""
+    """``FrigateManager._reload_implementation`` records the manager's
+    own health based on what reload actually does (DB read + client
+    construction). The api_health_status slot is reserved for actual
+    API-call outcomes set by ``api_call_context`` wrappers; reload
+    never touches it because reload doesn't call the API."""
 
     def setUp(self):
-        # Fresh manager per test — the singleton retains health state
-        # across tests otherwise.
+        # FrigateManager is a singleton — health state from prior tests
+        # leaks otherwise. Force a fresh provider setup on both slots.
         self.manager = FrigateManager()
+        self.manager._health_status = self.manager.initial_health_status
+        if hasattr( self.manager, '_api_health_status' ):
+            del self.manager._api_health_status
 
-    def test_no_integration_row_marks_disabled(self):
+    def test_no_integration_row_records_disabled(self):
         Integration.objects.filter(
             integration_id = FrigateMetaData.integration_id,
         ).delete()
         self.manager._reload_implementation()
         self.assertEqual(
+            self.manager.health_status._base_status,
+            HealthStatusType.DISABLED,
+        )
+        self.assertEqual(
             self.manager.api_health_status.status,
-            ApiHealthStatusType.DISABLED,
+            ApiHealthStatusType.UNKNOWN,
         )
         self.assertIsNone( self.manager._frigate_client )
 
-    def test_disabled_integration_marks_disabled(self):
+    def test_disabled_integration_records_disabled(self):
         integration, _ = Integration.objects.get_or_create(
             integration_id = FrigateMetaData.integration_id,
             defaults = { 'is_enabled': False },
@@ -320,11 +324,16 @@ class TestFrigateManagerHealthRecording( TestCase ):
         integration.save()
         self.manager._reload_implementation()
         self.assertEqual(
-            self.manager.api_health_status.status,
-            ApiHealthStatusType.DISABLED,
+            self.manager.health_status._base_status,
+            HealthStatusType.DISABLED,
         )
+        self.assertEqual(
+            self.manager.api_health_status.status,
+            ApiHealthStatusType.UNKNOWN,
+        )
+        self.assertIsNone( self.manager._frigate_client )
 
-    def test_successful_reload_marks_healthy(self):
+    def test_successful_reload_records_manager_healthy_and_leaves_api_unknown(self):
         integration, _ = Integration.objects.get_or_create(
             integration_id = FrigateMetaData.integration_id,
             defaults = { 'is_enabled': True },
@@ -337,12 +346,16 @@ class TestFrigateManagerHealthRecording( TestCase ):
         ):
             self.manager._reload_implementation()
         self.assertEqual(
+            self.manager.health_status._base_status,
+            HealthStatusType.HEALTHY,
+        )
+        self.assertEqual(
             self.manager.api_health_status.status,
-            ApiHealthStatusType.HEALTHY,
+            ApiHealthStatusType.UNKNOWN,
         )
         self.assertIsNotNone( self.manager._frigate_client )
 
-    def test_client_build_failure_marks_unavailable(self):
+    def test_client_build_failure_records_manager_error_and_leaves_api_unknown(self):
         integration, _ = Integration.objects.get_or_create(
             integration_id = FrigateMetaData.integration_id,
             defaults = { 'is_enabled': True },
@@ -354,12 +367,13 @@ class TestFrigateManagerHealthRecording( TestCase ):
             side_effect = ValueError( 'Base URL is required.' ),
         ):
             self.manager._reload_implementation()
-        # record_error pushes the API status to UNAVAILABLE so the
-        # aggregate maps the manager's own slot to ERROR rather than
-        # the leak-through WARNING that UNKNOWN would produce.
+        self.assertEqual(
+            self.manager.health_status._base_status,
+            HealthStatusType.ERROR,
+        )
         self.assertEqual(
             self.manager.api_health_status.status,
-            ApiHealthStatusType.UNAVAILABLE,
+            ApiHealthStatusType.UNKNOWN,
         )
         self.assertIsNone( self.manager._frigate_client )
 


### PR DESCRIPTION
## Pull Request: Frigate: correct _reload_implementation health claims

### Issue Link

Closes #348

---

## Category

- [ ] **Feature** (New functionality)
- [x] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- `FrigateManager._reload_implementation` no longer sets `api_health_status` at all. Reload doesn't talk to Frigate — it loads attributes from the DB and constructs a config wrapper — so claiming HEALTHY (or UNAVAILABLE on a config-only construction failure) was making false claims about API state.
- Per-branch recording now goes through `HealthStatusProvider.record_*` calls reflecting what reload can actually attest to: `record_disabled` on the disabled / no-row paths, `record_error` on the construction-failed path, `record_healthy('Reloaded')` on the successful build path.
- `api_health_status` is now exclusively touched by the `api_call_context` wrappers around real API calls — the cleaner separation between "did the manager load" and "is the API reachable".
- `TestFrigateManagerHealthRecording` reworked: assert `health_status._base_status` for the manager-level claim and `api_health_status.status == UNKNOWN` for the no-touch invariant. Test class docstring rewritten to reflect the corrected posture.

Per the consumer audit on the issue (banner tag, system info page, integration manage/save views, system health provider map): every UI surface that reads per-integration manager health either gates on `is_enabled` upstream or is unreachable for disabled integrations. So the disabled-branch `record_disabled` calls have no UI consumer today, but were kept because the branches already exist and need to write *something* to keep the manager's `_base_status` aligned with reality — cheaper than adding a special "do nothing on this branch" carve-out.

---

## How to Test

1. From a Django shell:
   ```python
   from hi.services.frigate.frigate_manager import FrigateManager
   fm = FrigateManager()
   fm.ensure_initialized()
   print(fm.api_health_status.status)            # 'unknown' (was 'healthy')
   print(fm.health_status._base_status)          # 'healthy' on enabled+configured
   ```
2. In a running app with Frigate enabled: restart. The integration health banner may briefly show WARNING (UNKNOWN → WARNING under `ALL_SOURCES_HEALTHY` aggregation) for one polling interval, then HEALTHY once the first wrapped API call lands. This is intentional honest signaling, not a regression.
3. Configure Frigate with an invalid `base_url` so client construction fails: banner shows ERROR from the manager's `record_error`; `api_health_status` stays UNKNOWN.
4. Disable Frigate: no banner surface renders (consumers all gate on `is_enabled`).
5. Run `./manage.py test hi.services.frigate.tests.test_frigate_integration.TestFrigateManagerHealthRecording` — four tests, all pass.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

#347 (Frigate integration v1) — the rewrite where the false-claim pattern was originally introduced.

---

## Screenshots (if applicable)

None — no UI changes.

---

## Additional Notes

The transient WARNING banner on the happy path is intentional. If it becomes annoying in practice, the right surface to address is the aggregator's UNKNOWN handling (separate decision), not by overclaiming HEALTHY at reload time.

---

### **Ready for Review?**

- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
