### PR TITLE
Rebalance EntityGroupType + hide delegates from edit sidebar (#367)

### DIFF
--- a/docs/dev/frontend/entity-visual-configuration.md
+++ b/docs/dev/frontend/entity-visual-configuration.md
@@ -58,7 +58,7 @@ For the existing palette of `StatusStyle` instances and the status-value vocabul
 
 ### 3. Assign the type to an `EntityGroupType` bucket
 
-Every new `EntityType` must be added to exactly one `EntityGroupType.entity_type_set` in [`src/hi/apps/entity/enums.py`](../../../src/hi/apps/entity/enums.py). The buckets organize the entity-editing and collection-editing UI group lists and serve as the default grouping dimension on the integration placement modal — a type with no explicit assignment is invisible in those surfaces (it falls into `OTHER`, which is reserved for `EntityType.OTHER`).
+Every new `EntityType` must be added to exactly one `EntityGroupType.entity_type_set` in [`src/hi/apps/entity/enums.py`](../../../src/hi/apps/entity/enums.py). The buckets organize the entity-editing and collection-editing UI group lists and serve as the default grouping dimension on the integration placement modal — a type with no explicit assignment silently falls into `GENERAL`. Pick the most natural domain bucket (`AUTOMATION`, `SECURITY`, `APPLIANCES`, etc.); reserve `GENERAL` for types that genuinely don't fit a domain.
 
 ## Visual asset guidelines
 

--- a/docs/dev/frontend/entity-visual-configuration.md
+++ b/docs/dev/frontend/entity-visual-configuration.md
@@ -56,6 +56,10 @@ For the existing palette of `StatusStyle` instances and the status-value vocabul
 
 **Optional**: customize default path sizing in `EntityStyle.EntityTypePathInitialRadius` if your area type wants a non-default initial radius when first created.
 
+### 3. Assign the type to an `EntityGroupType` bucket
+
+Every new `EntityType` must be added to exactly one `EntityGroupType.entity_type_set` in [`src/hi/apps/entity/enums.py`](../../../src/hi/apps/entity/enums.py). The buckets organize the entity-editing and collection-editing UI group lists and serve as the default grouping dimension on the integration placement modal — a type with no explicit assignment is invisible in those surfaces (it falls into `OTHER`, which is reserved for `EntityType.OTHER`).
+
 ## Visual asset guidelines
 
 ### SVG icon design

--- a/src/hi/apps/collection/collection_manager.py
+++ b/src/hi/apps/collection/collection_manager.py
@@ -343,9 +343,15 @@ class CollectionManager(Singleton):
 
     def create_entity_collection_group_list( self,
                                              collection : Collection,
-                                             unused_entity_ids : set = None ) -> List[EntityCollectionGroup]:
+                                             unused_entity_ids : set = None,
+                                             exclude_delegates : bool = False,
+                                             ) -> List[EntityCollectionGroup]:
 
         entity_queryset = Entity.objects.all()
+        if exclude_delegates:
+            entity_queryset = entity_queryset.exclude(
+                entity_state_delegations__isnull = False,
+            )
 
         if unused_entity_ids is None:
             unused_entity_ids = set()

--- a/src/hi/apps/collection/edit/views.py
+++ b/src/hi/apps/collection/edit/views.py
@@ -254,6 +254,7 @@ class CollectionManageItemsView( HiSideView ):
         entity_collection_group_list = CollectionManager().create_entity_collection_group_list(
             collection = collection,
             unused_entity_ids = unused_entity_ids,
+            exclude_delegates = True,
         )
         return {
             'entity_collection_group_list': entity_collection_group_list,

--- a/src/hi/apps/collection/tests/test_collection_manager.py
+++ b/src/hi/apps/collection/tests/test_collection_manager.py
@@ -71,18 +71,18 @@ class TestCollectionManagerIntegration(BaseTestCase):
         # Should have groups for each entity type present in system
         group_types = {group.entity_group_type for group in groups}
         self.assertIn(EntityGroupType.SECURITY, group_types)  # Contains cameras
-        self.assertIn(EntityGroupType.LIGHTS_SWITCHES, group_types)  # Contains lights
-        
+        self.assertIn(EntityGroupType.AUTOMATION, group_types)  # Contains lights
+
         # Find security group (contains cameras) and verify contents
         camera_group = next(g for g in groups if g.entity_group_type == EntityGroupType.SECURITY)
         camera_items = {item.entity.name: item.exists_in_collection for item in camera_group.item_list}
-        
+
         self.assertEqual(len(camera_items), 2)
         self.assertTrue(camera_items['Front Camera'])  # In collection
         self.assertFalse(camera_items['Back Camera'])  # Not in collection
-        
-        # Find light group and verify contents
-        light_group = next(g for g in groups if g.entity_group_type == EntityGroupType.LIGHTS_SWITCHES)
+
+        # Find automation group (light lives here post-rebalance) and verify contents
+        light_group = next(g for g in groups if g.entity_group_type == EntityGroupType.AUTOMATION)
         self.assertEqual(len(light_group.item_list), 1)
         self.assertTrue(light_group.item_list[0].exists_in_collection)
         

--- a/src/hi/apps/collection/tests/test_collection_manager.py
+++ b/src/hi/apps/collection/tests/test_collection_manager.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock
 
 from hi.apps.collection.collection_manager import CollectionManager
 from hi.apps.collection.models import Collection, CollectionEntity, CollectionPosition, CollectionView, CollectionPath
-from hi.apps.entity.models import Entity
-from hi.apps.entity.enums import EntityGroupType
+from hi.apps.entity.models import Entity, EntityState, EntityStateDelegation
+from hi.apps.entity.enums import EntityGroupType, EntityStateType, EntityType
 from hi.apps.location.models import Location, LocationView
 from hi.testing.base_test_case import BaseTestCase
 
@@ -682,4 +682,69 @@ class TestCollectionManagerCreateCollection(BaseTestCase):
         manager.create_collection(name='Inventory')
         third = manager.create_collection(name='Inventory')
         self.assertEqual(third.name, 'Inventory (3)')
+
+
+class TestCreateEntityCollectionGroupListExcludeDelegates(BaseTestCase):
+    """``exclude_delegates`` hides entities that act as delegates of
+    some principal, so the edit-mode sidebar doesn't surface them
+    as separately-toggleable checkboxes."""
+
+    def _make_principal_with_delegate(self):
+        principal = Entity.objects.create(
+            name='Motion Sensor',
+            entity_type_str=str(EntityType.MOTION_SENSOR),
+        )
+        delegate_area = Entity.objects.create(
+            name='Living Room',
+            entity_type_str=str(EntityType.AREA),
+        )
+        state = EntityState.objects.create(
+            entity=principal,
+            entity_state_type_str=str(EntityStateType.MOVEMENT),
+            name='movement',
+        )
+        EntityStateDelegation.objects.create(
+            entity_state=state,
+            delegate_entity=delegate_area,
+        )
+        return principal, delegate_area
+
+    def _names_in_groups(self, group_list):
+        return {
+            item.entity.name
+            for group in group_list
+            for item in group.item_list
+        }
+
+    def _make_collection(self):
+        return Collection.objects.create(
+            name='Test Collection',
+            collection_type_str='OTHER',
+            collection_view_type_str='LIST',
+        )
+
+    def test_delegate_hidden_when_exclude_delegates_true(self):
+        principal, delegate_area = self._make_principal_with_delegate()
+        collection = self._make_collection()
+
+        group_list = CollectionManager().create_entity_collection_group_list(
+            collection=collection,
+            exclude_delegates=True,
+        )
+
+        names = self._names_in_groups(group_list)
+        self.assertIn(principal.name, names)
+        self.assertNotIn(delegate_area.name, names)
+
+    def test_delegate_visible_by_default(self):
+        principal, delegate_area = self._make_principal_with_delegate()
+        collection = self._make_collection()
+
+        group_list = CollectionManager().create_entity_collection_group_list(
+            collection=collection,
+        )
+
+        names = self._names_in_groups(group_list)
+        self.assertIn(principal.name, names)
+        self.assertIn(delegate_area.name, names)
 

--- a/src/hi/apps/entity/entity_manager.py
+++ b/src/hi/apps/entity/entity_manager.py
@@ -84,10 +84,16 @@ class EntityManager(Singleton):
 
     def create_location_entity_view_group_list( self,
                                                 location_view : LocationView,
-                                                unused_entity_ids : set = None ) -> List[EntityViewGroup]:
+                                                unused_entity_ids : set = None,
+                                                exclude_delegates : bool = False,
+                                                ) -> List[EntityViewGroup]:
         existing_entities = [ x.entity
                               for x in location_view.entity_views.select_related('entity').all() ]
         all_entities = Entity.objects.all()
+        if exclude_delegates:
+            all_entities = all_entities.exclude(
+                entity_state_delegations__isnull = False,
+            )
         return self.create_entity_view_group_list(
             existing_entities = existing_entities,
             all_entities = all_entities,

--- a/src/hi/apps/entity/enums.py
+++ b/src/hi/apps/entity/enums.py
@@ -564,6 +564,18 @@ class VideoStreamType(LabeledEnum):
 
 
 class EntityGroupType(LabeledEnum):
+    """Rollup of leaf ``EntityType`` values into ~15 broader buckets
+    that match how a homeowner organizes their LocationView floor
+    plans and CollectionViews. Surfaced in the entity-editing and
+    collection-editing group lists, and used as the default
+    grouping dimension by integration placement modals.
+
+    Bucket-assignment invariants pinned by ``test_enums.py``:
+      - Every ``EntityType`` other than ``EntityType.OTHER`` lives
+        in exactly one non-``OTHER`` bucket (no silent fallbacks).
+      - ``EntityGroupType.OTHER`` is reserved for ``EntityType.OTHER``.
+      - ``GENERAL`` is the named catchall for known-but-uncategorizable
+        types — distinct from the silent ``OTHER`` fallback."""
 
     APPLIANCES = ( 'Appliances', '', {
         EntityType.APPLIANCE,
@@ -573,16 +585,23 @@ class EntityGroupType(LabeledEnum):
         EntityType.COFFEE_MAKER,
         EntityType.COOKTOP,
         EntityType.DISHWASHER,
+        EntityType.EXHAUST_FAN,
+        EntityType.FREEZER,
         EntityType.GARBAGE_DISPOSAL,
         EntityType.GRILL,
+        EntityType.HUMIDIFIER,
+        EntityType.HVAC_AIR_HANDLER,
+        EntityType.HVAC_CONDENSER,
+        EntityType.HVAC_FURNACE,
+        EntityType.HVAC_MINI_SPLIT,
         EntityType.MICROWAVE_OVEN,
         EntityType.OVEN,
         EntityType.RANGE_HOOD,
         EntityType.REFRIGERATOR,
+        EntityType.THERMOSTAT,
+        EntityType.WATER_FILTER,
         EntityType.WATER_HEATER,
-    })
-    AREAS = ( 'Areas', '', {
-        EntityType.AREA,
+        EntityType.WATER_SOFTENER,
     })
     AUDIO_VISUAL = ( 'Audio/Visual', '', {
         EntityType.AV_RECEIVER,
@@ -590,23 +609,18 @@ class EntityGroupType(LabeledEnum):
         EntityType.SPEAKER_WIRE,
         EntityType.TELEVISION,
     })
-    AUTO = ( 'Auto', '', {
-        EntityType.AUTOMOBILE,
+    AUTOMATION = ( 'Automation', '', {
+        EntityType.CONTROLLER,
+        EntityType.DOOR_LOCK,
+        EntityType.ELECTRICAL_OUTLET,
+        EntityType.GARAGE_DOOR_OPENER,
+        EntityType.IRRIGATION_CONTROLLER,
+        EntityType.LIGHT,
+        EntityType.ON_OFF_SWITCH,
+        EntityType.OPEN_CLOSE_ACTUATOR,
+        EntityType.WALL_SWITCH,
     })
-    CLIMATE = ( 'Climate', '', {
-        EntityType.BAROMETER,
-        EntityType.CONTROL_WIRE,
-        EntityType.EXHAUST_FAN,
-        EntityType.HUMIDIFIER,
-        EntityType.HVAC_AIR_HANDLER,
-        EntityType.HVAC_CONDENSER,
-        EntityType.HVAC_FURNACE,
-        EntityType.HVAC_MINI_SPLIT,
-        EntityType.HYGROMETER,
-        EntityType.THERMOMETER,
-        EntityType.THERMOSTAT,
-    })
-    COMPUTER_NETWORK = ( 'Computer/Network', '', {
+    COMPUTERS = ( 'Computers', '', {
         EntityType.ACCESS_POINT,
         EntityType.COMPUTER,
         EntityType.DISK,
@@ -617,11 +631,18 @@ class EntityGroupType(LabeledEnum):
         EntityType.SERVER,
         EntityType.SERVICE,
     })
-    CONSUMABLES = ( 'Consumable', '', {
-        EntityType.CONSUMABLE,
+    ELECTRICAL = ( 'Electrical', '', {
+        EntityType.BATTERY_STORAGE,
+        EntityType.CONTROL_WIRE,
+        EntityType.ELECTRIC_PANEL,
+        EntityType.ELECTRIC_WIRE,
+        EntityType.EV_CHARGER,
+        EntityType.GENERATOR,
+        EntityType.INVERTER,
+        EntityType.SOLAR_PANEL,
+        EntityType.UPS,
     })
     FIXTURES = ( 'Fixtures', '', {
-        EntityType.ATTIC_STAIRS,
         EntityType.BATHTUB,
         EntityType.CEILING_FAN,
         EntityType.FURNITURE,
@@ -630,77 +651,84 @@ class EntityGroupType(LabeledEnum):
         EntityType.TOILET,
         EntityType.VANITY,
     })
-    LIGHTS_SWITCHES = ( 'Lights, Switches, Outlets', '', {
-        EntityType.ELECTRICAL_OUTLET,
-        EntityType.LIGHT,
-        EntityType.ON_OFF_SWITCH,
-        EntityType.WALL_SWITCH,
-    })
-    OTHER = ( 'Other', '', {
-        EntityType.OPEN_CLOSE_ACTUATOR,
-        EntityType.OTHER,
+    GENERAL = ( 'General', '', {
+        EntityType.AREA,
+        EntityType.AUTOMOBILE,
+        EntityType.CONSUMABLE,
+        EntityType.MOTOR,
+        EntityType.PUMP,
+        EntityType.SUMP_PUMP,
     })
     OUTDOORS = ( 'Outdoors', '', {
         EntityType.FENCE,
-        EntityType.CONTROLLER,
         EntityType.GREENHOUSE,
-        EntityType.HEDGE_TRIMMER,
-        EntityType.LAWN_MOWER,
-        EntityType.LEAF_BLOWER,
-        EntityType.MOTOR,
-        EntityType.PIPE,
         EntityType.PLANT,
-        EntityType.POOL_FILTER,
-        EntityType.POWER_WASHER,
-        EntityType.PUMP,
         EntityType.SPRINKLER_HEAD,
         EntityType.SPRINKLER_VALVE,
         EntityType.SPRINKLER_WIRE,
         EntityType.TREE,
-        EntityType.TRIMMER,
+    })
+    POOL = ( 'Pool', '', {
+        EntityType.POOL_FILTER,
+        EntityType.POOL_HEATER,
+        EntityType.POOL_PUMP,
+        EntityType.POOL_SWG,
     })
     SECURITY = ( 'Security', '', {
         EntityType.CAMERA,
         EntityType.CARBON_MONOXIDE_DETECTOR,
         EntityType.DOORBELL,
-        EntityType.DOOR_LOCK,
         EntityType.FIRE_EXTINGUISHER,
-        EntityType.LIGHT_SENSOR,
+        EntityType.GAS_DETECTOR,
+        EntityType.LEAK_SENSOR,
         EntityType.MOTION_SENSOR,
         EntityType.OPEN_CLOSE_SENSOR,
         EntityType.PRESENCE_SENSOR,
+        EntityType.RADON_DETECTOR,
         EntityType.SMOKE_DETECTOR,
     })
-    STRUCTURAL = ( 'Structural', '', {
-        EntityType.DOOR,
-        EntityType.FIREPLACE,
-        EntityType.SKYLIGHT,
-        EntityType.WINDOW,
-        EntityType.WALL,
-    })
-    TIME_WEATHER = ( 'Time/Weather', '', {
+    SENSORS = ( 'Sensors', '', {
+        EntityType.BAROMETER,
+        EntityType.HYGROMETER,
+        EntityType.LIGHT_SENSOR,
+        EntityType.THERMOMETER,
         EntityType.TIME_SOURCE,
         EntityType.WEATHER_STATION,
     })
+    STRUCTURAL = ( 'Structural', '', {
+        EntityType.ATTIC_STAIRS,
+        EntityType.DOOR,
+        EntityType.FIREPLACE,
+        EntityType.GARAGE_DOOR,
+        EntityType.SKYLIGHT,
+        EntityType.WALL,
+        EntityType.WINDOW,
+    })
     TOOLS = ( 'Tools', '', {
+        EntityType.HEDGE_TRIMMER,
+        EntityType.LAWN_MOWER,
+        EntityType.LEAF_BLOWER,
+        EntityType.POWER_WASHER,
         EntityType.TOOL,
+        EntityType.TRIMMER,
     })
     UTILITIES = ( 'Utilities', '', {
         EntityType.ANTENNA,
         EntityType.DRAINAGE_PIPE,
         EntityType.ELECTRICITY_METER,
-        EntityType.ELECTRIC_PANEL,
-        EntityType.ELECTRIC_WIRE,
-        EntityType.GENERATOR,
+        EntityType.GAS_LINE,
+        EntityType.GAS_METER,
+        EntityType.PIPE,
         EntityType.SATELLITE_DISH,
         EntityType.SEWER_LINE,
-        EntityType.SOLAR_PANEL,
         EntityType.TELECOM_BOX,
         EntityType.TELECOM_WIRE,
-        EntityType.UPS,
         EntityType.WATER_LINE,
         EntityType.WATER_METER,
         EntityType.WATER_SHUTOFF_VALVE,
+    })
+    OTHER = ( 'Other', '', {
+        EntityType.OTHER,
     })
     
     def __init__( self,

--- a/src/hi/apps/entity/enums.py
+++ b/src/hi/apps/entity/enums.py
@@ -564,18 +564,17 @@ class VideoStreamType(LabeledEnum):
 
 
 class EntityGroupType(LabeledEnum):
-    """Rollup of leaf ``EntityType`` values into ~15 broader buckets
-    that match how a homeowner organizes their LocationView floor
-    plans and CollectionViews. Surfaced in the entity-editing and
+    """Rollup of leaf ``EntityType`` values into broader buckets that
+    match how a homeowner organizes their LocationView floor plans
+    and CollectionViews. Surfaced in the entity-editing and
     collection-editing group lists, and used as the default
     grouping dimension by integration placement modals.
 
     Bucket-assignment invariants pinned by ``test_enums.py``:
-      - Every ``EntityType`` other than ``EntityType.OTHER`` lives
-        in exactly one non-``OTHER`` bucket (no silent fallbacks).
-      - ``EntityGroupType.OTHER`` is reserved for ``EntityType.OTHER``.
-      - ``GENERAL`` is the named catchall for known-but-uncategorizable
-        types — distinct from the silent ``OTHER`` fallback."""
+      - Every ``EntityType`` is explicitly assigned to exactly one
+        bucket — no silent fallbacks.
+      - ``GENERAL`` is the catchall for types that don't fit a
+        domain bucket; ``EntityType.OTHER`` lives there too."""
 
     APPLIANCES = ( 'Appliances', '', {
         EntityType.APPLIANCE,
@@ -639,7 +638,10 @@ class EntityGroupType(LabeledEnum):
         EntityType.EV_CHARGER,
         EntityType.GENERATOR,
         EntityType.INVERTER,
+        EntityType.MOTOR,
+        EntityType.PUMP,
         EntityType.SOLAR_PANEL,
+        EntityType.SUMP_PUMP,
         EntityType.UPS,
     })
     FIXTURES = ( 'Fixtures', '', {
@@ -652,12 +654,9 @@ class EntityGroupType(LabeledEnum):
         EntityType.VANITY,
     })
     GENERAL = ( 'General', '', {
-        EntityType.AREA,
         EntityType.AUTOMOBILE,
         EntityType.CONSUMABLE,
-        EntityType.MOTOR,
-        EntityType.PUMP,
-        EntityType.SUMP_PUMP,
+        EntityType.OTHER,
     })
     OUTDOORS = ( 'Outdoors', '', {
         EntityType.FENCE,
@@ -696,6 +695,7 @@ class EntityGroupType(LabeledEnum):
         EntityType.WEATHER_STATION,
     })
     STRUCTURAL = ( 'Structural', '', {
+        EntityType.AREA,
         EntityType.ATTIC_STAIRS,
         EntityType.DOOR,
         EntityType.FIREPLACE,
@@ -727,9 +727,6 @@ class EntityGroupType(LabeledEnum):
         EntityType.WATER_METER,
         EntityType.WATER_SHUTOFF_VALVE,
     })
-    OTHER = ( 'Other', '', {
-        EntityType.OTHER,
-    })
     
     def __init__( self,
                   label             : str,
@@ -741,8 +738,8 @@ class EntityGroupType(LabeledEnum):
 
     @classmethod
     def default(cls):
-        return cls.OTHER
- 
+        return cls.GENERAL
+
     @classmethod
     def from_entity_type( cls, entity_type : EntityType ):
         for entity_group_type in cls:

--- a/src/hi/apps/entity/tests/test_entity_manager.py
+++ b/src/hi/apps/entity/tests/test_entity_manager.py
@@ -1,8 +1,13 @@
 import logging
 
 from hi.apps.entity.entity_manager import EntityManager
-from hi.apps.entity.models import Entity
-from hi.apps.entity.enums import EntityGroupType, EntityType
+from hi.apps.entity.models import (
+    Entity,
+    EntityState,
+    EntityStateDelegation,
+)
+from hi.apps.entity.enums import EntityGroupType, EntityStateType, EntityType
+from hi.apps.location.tests.synthetic_data import LocationSyntheticData
 from hi.testing.base_test_case import BaseTestCase
 
 logging.disable(logging.CRITICAL)
@@ -189,7 +194,85 @@ class TestEntityManager(BaseTestCase):
             
             if camera_item:
                 self.assertFalse(camera_item.exists_in_view)
-        
+
         return
+
+
+class TestCreateLocationEntityViewGroupListExcludeDelegates(BaseTestCase):
+    """``exclude_delegates`` hides entities that act as delegates of
+    some principal, so the edit-mode sidebar doesn't surface them
+    as separately-toggleable checkboxes."""
+
+    def _make_principal_with_delegate(self):
+        principal = Entity.objects.create(
+            name='Motion Sensor',
+            entity_type_str=str(EntityType.MOTION_SENSOR),
+        )
+        delegate_area = Entity.objects.create(
+            name='Living Room',
+            entity_type_str=str(EntityType.AREA),
+        )
+        state = EntityState.objects.create(
+            entity=principal,
+            entity_state_type_str=str(EntityStateType.MOVEMENT),
+            name='movement',
+        )
+        EntityStateDelegation.objects.create(
+            entity_state=state,
+            delegate_entity=delegate_area,
+        )
+        return principal, delegate_area
+
+    def _names_in_groups(self, group_list):
+        return {
+            item.entity.name
+            for group in group_list
+            for item in group.item_list
+        }
+
+    def test_delegate_hidden_when_exclude_delegates_true(self):
+        principal, delegate_area = self._make_principal_with_delegate()
+        location_view = LocationSyntheticData.create_test_location_view()
+
+        group_list = EntityManager().create_location_entity_view_group_list(
+            location_view=location_view,
+            exclude_delegates=True,
+        )
+
+        names = self._names_in_groups(group_list)
+        self.assertIn(principal.name, names)
+        self.assertNotIn(delegate_area.name, names)
+
+    def test_delegate_visible_by_default(self):
+        # Default (exclude_delegates=False) preserves the pre-change
+        # behavior so the pairings modal and any other caller keeps
+        # seeing delegates.
+        principal, delegate_area = self._make_principal_with_delegate()
+        location_view = LocationSyntheticData.create_test_location_view()
+
+        group_list = EntityManager().create_location_entity_view_group_list(
+            location_view=location_view,
+        )
+
+        names = self._names_in_groups(group_list)
+        self.assertIn(principal.name, names)
+        self.assertIn(delegate_area.name, names)
+
+    def test_non_delegate_entity_unaffected_by_filter(self):
+        # An entity that is neither principal nor delegate keeps
+        # appearing whether the filter is on or off.
+        plain = Entity.objects.create(
+            name='Standalone Light',
+            entity_type_str=str(EntityType.LIGHT),
+        )
+        location_view = LocationSyntheticData.create_test_location_view()
+
+        group_list = EntityManager().create_location_entity_view_group_list(
+            location_view=location_view,
+            exclude_delegates=True,
+        )
+
+        names = self._names_in_groups(group_list)
+        self.assertIn(plain.name, names)
 
 

--- a/src/hi/apps/entity/tests/test_entity_manager.py
+++ b/src/hi/apps/entity/tests/test_entity_manager.py
@@ -154,18 +154,18 @@ class TestEntityManager(BaseTestCase):
         sorted_labels = sorted(group_labels)
         self.assertEqual(group_labels, sorted_labels)
         
-        # Find the lights/switches group and verify light entity exists in view
-        lights_group = None
+        # Find the automation group (where LIGHT lives) and verify
+        # the light entity is marked as existing in the view.
+        automation_group = None
         for group in group_list:
-            if group.entity_group_type == EntityGroupType.LIGHTS_SWITCHES:
-                lights_group = group
+            if group.entity_group_type == EntityGroupType.AUTOMATION:
+                automation_group = group
                 break
-        
-        self.assertIsNotNone(lights_group)
-        
-        # Find light entity in the group and verify it's marked as existing
+
+        self.assertIsNotNone(automation_group)
+
         light_item = None
-        for item in lights_group.item_list:
+        for item in automation_group.item_list:
             if item.entity == light_entity:
                 light_item = item
                 break

--- a/src/hi/apps/entity/tests/test_enums.py
+++ b/src/hi/apps/entity/tests/test_enums.py
@@ -19,156 +19,308 @@ class TestEntityStateTypeDefaultRole(BaseTestCase):
         # KeyError at runtime; this test surfaces that at test time.
         for entity_state_type in EntityStateType:
             role = entity_state_type.default_role()
-            self.assertEqual( role.name, entity_state_type.name )
+            self.assertEqual(role.name, entity_state_type.name)
         return
 
 
-class TestEntityGroupType(BaseTestCase):
+class TestEntityGroupTypeAssignments(BaseTestCase):
+    """Pin a sample of EntityType → EntityGroupType assignments that
+    the rebalance settled on. These are the load-bearing cases —
+    things a user would obviously expect to find in a given bucket.
+    The full assignment table lives in the enum itself; the
+    coverage test below ensures no leaf type slips through."""
 
-    def test_entity_type_to_group_mapping_supports_logical_ui_organization(self):
-        """Test entity type to group mapping - organizes entities logically for user interface."""
-        # Test that common entity types map to expected functional groups
-        
-        # Lighting and electrical controls should group together
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.LIGHT),
-                         EntityGroupType.LIGHTS_SWITCHES)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.ON_OFF_SWITCH),
-                         EntityGroupType.LIGHTS_SWITCHES)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.ELECTRICAL_OUTLET),
-                         EntityGroupType.LIGHTS_SWITCHES)
-        
-        # Security devices should group together
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.CAMERA),
-                         EntityGroupType.SECURITY)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.MOTION_SENSOR),
-                         EntityGroupType.SECURITY)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.DOOR_LOCK),
-                         EntityGroupType.SECURITY)
-        
-        # Appliances should group together
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.REFRIGERATOR),
-                         EntityGroupType.APPLIANCES)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.DISHWASHER),
-                         EntityGroupType.APPLIANCES)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.CLOTHES_WASHER),
-                         EntityGroupType.APPLIANCES)
-        
-        # Climate control devices should group together
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.THERMOSTAT),
-                         EntityGroupType.CLIMATE)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.HVAC_FURNACE),
-                         EntityGroupType.CLIMATE)
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.HUMIDIFIER),
-                         EntityGroupType.CLIMATE)
-        
-        # Test fallback behavior for unmapped types
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.OTHER),
-                         EntityGroupType.OTHER)
-        
-        return
+    def test_automation_subsumes_lights_outlets_switches_and_actuators(self):
+        for et in (
+                EntityType.LIGHT,
+                EntityType.ELECTRICAL_OUTLET,
+                EntityType.ON_OFF_SWITCH,
+                EntityType.WALL_SWITCH,
+                EntityType.OPEN_CLOSE_ACTUATOR,
+                EntityType.GARAGE_DOOR_OPENER,
+                EntityType.DOOR_LOCK,
+                EntityType.CONTROLLER,
+                EntityType.IRRIGATION_CONTROLLER):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.AUTOMATION,
+                msg=f'{et.name} expected in AUTOMATION',
+            )
 
-    def test_entity_group_sets_provide_comprehensive_categorization(self):
-        """Test entity type set coverage - ensures all important device types are properly categorized."""
-        # Test that major appliance categories are well-represented
-        appliances = EntityGroupType.APPLIANCES
-        expected_appliances = [
-            EntityType.REFRIGERATOR,
-            EntityType.DISHWASHER, 
-            EntityType.CLOTHES_WASHER,
-            EntityType.CLOTHES_DRYER,
-            EntityType.MICROWAVE_OVEN,
-            EntityType.WATER_HEATER
-        ]
-        
-        for appliance_type in expected_appliances:
-            self.assertIn(appliance_type, appliances.entity_type_set,
-                          f"{appliance_type} should be in APPLIANCES group")
-        
-        # Test that security devices are comprehensively covered
-        security = EntityGroupType.SECURITY
-        expected_security = [
-            EntityType.CAMERA,
-            EntityType.MOTION_SENSOR,
-            EntityType.DOOR_LOCK,
-            EntityType.PRESENCE_SENSOR,
-            EntityType.OPEN_CLOSE_SENSOR
-        ]
-        
-        for security_type in expected_security:
-            self.assertIn(security_type, security.entity_type_set,
-                          f"{security_type} should be in SECURITY group")
-        
-        # Test that climate control devices are well-categorized
-        climate = EntityGroupType.CLIMATE
-        expected_climate = [
-            EntityType.THERMOSTAT,
-            EntityType.HVAC_FURNACE,
-            EntityType.HVAC_AIR_HANDLER,
-            EntityType.HUMIDIFIER,
-            EntityType.THERMOMETER
-        ]
-        
-        for climate_type in expected_climate:
-            self.assertIn(climate_type, climate.entity_type_set,
-                          f"{climate_type} should be in CLIMATE group")
-        
-        # Test that no entity type appears in multiple groups (mutual exclusivity)
-        all_groups = list(EntityGroupType)
-        all_entity_types_in_groups = set()
-        
-        for group in all_groups:
-            # Check for overlaps
-            overlap = all_entity_types_in_groups.intersection(group.entity_type_set)
-            self.assertEqual(len(overlap), 0,
-                             f"Group {group} has overlapping entity types: {overlap}")
-            all_entity_types_in_groups.update(group.entity_type_set)
-        
-        return
+    def test_security_carries_alarm_sensors(self):
+        for et in (
+                EntityType.CAMERA,
+                EntityType.MOTION_SENSOR,
+                EntityType.OPEN_CLOSE_SENSOR,
+                EntityType.SMOKE_DETECTOR,
+                EntityType.CARBON_MONOXIDE_DETECTOR,
+                EntityType.GAS_DETECTOR,
+                EntityType.LEAK_SENSOR,
+                EntityType.RADON_DETECTOR):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.SECURITY,
+                msg=f'{et.name} expected in SECURITY',
+            )
 
-    def test_entity_group_fallback_logic_handles_unmapped_types(self):
-        """Test entity group fallback behavior - provides sensible defaults for edge cases."""
-        # Test that unknown entity types fall back to OTHER group
-        other_group = EntityGroupType.from_entity_type(EntityType.OTHER)
-        self.assertEqual(other_group, EntityGroupType.OTHER)
-        
-        # Test that the OTHER group contains the OTHER entity type
-        self.assertIn(EntityType.OTHER, EntityGroupType.OTHER.entity_type_set)
-        
-        # Test that the default class method returns OTHER
-        default_group = EntityGroupType.default()
-        self.assertEqual(default_group, EntityGroupType.OTHER)
-        
-        # Test consistency between from_entity_type fallback and default
-        self.assertEqual(EntityGroupType.from_entity_type(EntityType.OTHER),
-                         EntityGroupType.default())
-        
-        return
+    def test_sensors_carries_measurement_devices(self):
+        # SENSORS is the new home for pure-measurement devices,
+        # distinct from SECURITY's "is something wrong?" sensors.
+        for et in (
+                EntityType.BAROMETER,
+                EntityType.THERMOMETER,
+                EntityType.HYGROMETER,
+                EntityType.LIGHT_SENSOR,
+                EntityType.TIME_SOURCE,
+                EntityType.WEATHER_STATION):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.SENSORS,
+                msg=f'{et.name} expected in SENSORS',
+            )
 
-    def test_entity_group_labels_support_user_friendly_display(self):
-        """Test entity group labels - provide meaningful names for UI display."""
-        # Test that all groups have meaningful labels
-        expected_labels = {
-            EntityGroupType.APPLIANCES: 'Appliances',
-            EntityGroupType.SECURITY: 'Security', 
-            EntityGroupType.CLIMATE: 'Climate',
-            EntityGroupType.LIGHTS_SWITCHES: 'Lights, Switches, Outlets',
-            EntityGroupType.COMPUTER_NETWORK: 'Computer/Network',
-            EntityGroupType.AUDIO_VISUAL: 'Audio/Visual'
-        }
-        
-        for group, expected_label in expected_labels.items():
-            self.assertEqual(group.label, expected_label,
-                             f"{group} should have label '{expected_label}'")
-        
-        # Test that all group labels are non-empty strings
+    def test_appliances_absorbs_hvac_and_water_treatment(self):
+        # HVAC and water-treatment appliances landed in APPLIANCES
+        # in the rebalance — the old CLIMATE bucket is gone.
+        for et in (
+                EntityType.REFRIGERATOR,
+                EntityType.FREEZER,
+                EntityType.DISHWASHER,
+                EntityType.WATER_HEATER,
+                EntityType.HVAC_FURNACE,
+                EntityType.HVAC_AIR_HANDLER,
+                EntityType.HVAC_CONDENSER,
+                EntityType.HVAC_MINI_SPLIT,
+                EntityType.THERMOSTAT,
+                EntityType.HUMIDIFIER,
+                EntityType.EXHAUST_FAN,
+                EntityType.WATER_FILTER,
+                EntityType.WATER_SOFTENER):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.APPLIANCES,
+                msg=f'{et.name} expected in APPLIANCES',
+            )
+
+    def test_pool_is_dedicated_bucket(self):
+        for et in (
+                EntityType.POOL_FILTER,
+                EntityType.POOL_HEATER,
+                EntityType.POOL_PUMP,
+                EntityType.POOL_SWG):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.POOL,
+                msg=f'{et.name} expected in POOL',
+            )
+
+    def test_electrical_carries_in_home_distribution(self):
+        # ELECTRICAL is the in-home electrical infrastructure;
+        # incoming-service meters live in UTILITIES.
+        for et in (
+                EntityType.ELECTRIC_PANEL,
+                EntityType.ELECTRIC_WIRE,
+                EntityType.CONTROL_WIRE,
+                EntityType.GENERATOR,
+                EntityType.UPS,
+                EntityType.INVERTER,
+                EntityType.BATTERY_STORAGE,
+                EntityType.SOLAR_PANEL,
+                EntityType.EV_CHARGER):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.ELECTRICAL,
+                msg=f'{et.name} expected in ELECTRICAL',
+            )
+
+    def test_utilities_carries_incoming_services(self):
+        # UTILITIES is the incoming-service side: meters, supply
+        # lines, telecom inflow. In-home electrical distribution
+        # lives in ELECTRICAL.
+        for et in (
+                EntityType.ELECTRICITY_METER,
+                EntityType.GAS_METER,
+                EntityType.WATER_METER,
+                EntityType.GAS_LINE,
+                EntityType.WATER_LINE,
+                EntityType.SEWER_LINE,
+                EntityType.WATER_SHUTOFF_VALVE,
+                EntityType.ANTENNA,
+                EntityType.SATELLITE_DISH):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.UTILITIES,
+                msg=f'{et.name} expected in UTILITIES',
+            )
+
+    def test_tools_carries_yard_and_hand_tools(self):
+        for et in (
+                EntityType.TOOL,
+                EntityType.HEDGE_TRIMMER,
+                EntityType.LAWN_MOWER,
+                EntityType.LEAF_BLOWER,
+                EntityType.POWER_WASHER,
+                EntityType.TRIMMER):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.TOOLS,
+                msg=f'{et.name} expected in TOOLS',
+            )
+
+    def test_outdoors_carries_vegetation_fencing_and_irrigation(self):
+        # OUTDOORS no longer holds outdoor power tools (they
+        # moved to TOOLS) or pool equipment (POOL). Vegetation +
+        # fencing + irrigation hardware remain.
+        for et in (
+                EntityType.PLANT,
+                EntityType.TREE,
+                EntityType.FENCE,
+                EntityType.GREENHOUSE,
+                EntityType.SPRINKLER_HEAD,
+                EntityType.SPRINKLER_VALVE,
+                EntityType.SPRINKLER_WIRE):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.OUTDOORS,
+                msg=f'{et.name} expected in OUTDOORS',
+            )
+
+    def test_structural_carries_doors_windows_and_walls(self):
+        # The garage split: GARAGE_DOOR is structural; the
+        # opener is in AUTOMATION.
+        for et in (
+                EntityType.DOOR,
+                EntityType.GARAGE_DOOR,
+                EntityType.WINDOW,
+                EntityType.SKYLIGHT,
+                EntityType.ATTIC_STAIRS,
+                EntityType.WALL,
+                EntityType.FIREPLACE):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.STRUCTURAL,
+                msg=f'{et.name} expected in STRUCTURAL',
+            )
+
+    def test_general_catches_singletons_and_orphan_machinery(self):
+        # GENERAL replaces the old AREAS / AUTO / CONSUMABLES
+        # singletons and absorbs generic pumps/motors that
+        # don't fit a domain bucket.
+        for et in (
+                EntityType.AREA,
+                EntityType.AUTOMOBILE,
+                EntityType.CONSUMABLE,
+                EntityType.PUMP,
+                EntityType.MOTOR,
+                EntityType.SUMP_PUMP):
+            self.assertEqual(
+                EntityGroupType.from_entity_type(et),
+                EntityGroupType.GENERAL,
+                msg=f'{et.name} expected in GENERAL',
+            )
+
+
+class TestEntityGroupTypeInvariants(BaseTestCase):
+    """Structural invariants that must hold across any future
+    bucket rebalance."""
+
+    def test_every_entity_type_is_assigned_to_exactly_one_bucket(self):
+        """Full-coverage contract: every ``EntityType`` other than
+        ``EntityType.OTHER`` lives in exactly one non-``OTHER``
+        ``EntityGroupType``.
+
+        This pins the no-silent-fallback contract. Adding a new
+        EntityType without assigning it to a bucket would silently
+        route it to OTHER under ``from_entity_type``; this test
+        forces the author to make an explicit assignment."""
+        mapped: dict = {}
+        for group in EntityGroupType:
+            for entity_type in group.entity_type_set:
+                self.assertNotIn(
+                    entity_type, mapped,
+                    msg=(
+                        f'{entity_type.name} is in both '
+                        f'{mapped.get(entity_type)} and {group.name} '
+                        f'— buckets must be mutually exclusive'
+                    ),
+                )
+                mapped[entity_type] = group.name
+
+        for entity_type in EntityType:
+            self.assertIn(
+                entity_type, mapped,
+                msg=(
+                    f'{entity_type.name} is not assigned to any '
+                    f'EntityGroupType — every leaf type must have '
+                    f'an explicit bucket (no silent OTHER fallback)'
+                ),
+            )
+
+            assigned_bucket = mapped[entity_type]
+            if entity_type is EntityType.OTHER:
+                self.assertEqual(
+                    assigned_bucket, EntityGroupType.OTHER.name,
+                    msg='EntityType.OTHER must live in EntityGroupType.OTHER',
+                )
+            else:
+                self.assertNotEqual(
+                    assigned_bucket, EntityGroupType.OTHER.name,
+                    msg=(
+                        f'{entity_type.name} was assigned to OTHER; the '
+                        f'OTHER bucket is reserved for EntityType.OTHER '
+                        f'only. Use GENERAL for known-but-uncategorizable '
+                        f'types.'
+                    ),
+                )
+
+    def test_from_entity_type_resolves_consistently_with_membership(self):
+        # The lookup function must agree with the entity_type_set
+        # data — they're two views of the same fact.
+        for group in EntityGroupType:
+            for entity_type in group.entity_type_set:
+                self.assertEqual(
+                    EntityGroupType.from_entity_type(entity_type),
+                    group,
+                )
+
+    def test_default_returns_other(self):
+        self.assertEqual(EntityGroupType.default(), EntityGroupType.OTHER)
+
+
+class TestEntityGroupTypeLabels(BaseTestCase):
+    """Pin the user-facing label contract."""
+
+    def test_all_labels_are_non_empty_strings(self):
         for group in EntityGroupType:
             self.assertIsInstance(group.label, str)
             self.assertGreater(len(group.label), 0)
-            
-        # Test that labels are unique (no duplicates)
-        all_labels = [group.label for group in EntityGroupType]
-        unique_labels = set(all_labels)
-        self.assertEqual(len(all_labels), len(unique_labels),
-                         "All group labels should be unique")
-        
-        return
+
+    def test_all_labels_are_unique(self):
+        labels = [group.label for group in EntityGroupType]
+        self.assertEqual(
+            len(labels), len(set(labels)),
+            msg='EntityGroupType labels must be unique for stable UI sort',
+        )
+
+    def test_specific_labels(self):
+        # Pin the new bucket names so a rename surfaces here
+        # rather than silently in the UI.
+        expected = {
+            EntityGroupType.APPLIANCES: 'Appliances',
+            EntityGroupType.AUDIO_VISUAL: 'Audio/Visual',
+            EntityGroupType.AUTOMATION: 'Automation',
+            EntityGroupType.COMPUTERS: 'Computers',
+            EntityGroupType.ELECTRICAL: 'Electrical',
+            EntityGroupType.FIXTURES: 'Fixtures',
+            EntityGroupType.GENERAL: 'General',
+            EntityGroupType.OTHER: 'Other',
+            EntityGroupType.OUTDOORS: 'Outdoors',
+            EntityGroupType.POOL: 'Pool',
+            EntityGroupType.SECURITY: 'Security',
+            EntityGroupType.SENSORS: 'Sensors',
+            EntityGroupType.STRUCTURAL: 'Structural',
+            EntityGroupType.TOOLS: 'Tools',
+            EntityGroupType.UTILITIES: 'Utilities',
+        }
+        for group, label in expected.items():
+            self.assertEqual(group.label, label)

--- a/src/hi/apps/entity/tests/test_enums.py
+++ b/src/hi/apps/entity/tests/test_enums.py
@@ -114,9 +114,11 @@ class TestEntityGroupTypeAssignments(BaseTestCase):
                 msg=f'{et.name} expected in POOL',
             )
 
-    def test_electrical_carries_in_home_distribution(self):
+    def test_electrical_carries_in_home_distribution_and_motors(self):
         # ELECTRICAL is the in-home electrical infrastructure;
-        # incoming-service meters live in UTILITIES.
+        # incoming-service meters live in UTILITIES. Pumps and
+        # motors live here because they're driven electrically and
+        # don't fit a domain-specific bucket like POOL.
         for et in (
                 EntityType.ELECTRIC_PANEL,
                 EntityType.ELECTRIC_WIRE,
@@ -126,7 +128,10 @@ class TestEntityGroupTypeAssignments(BaseTestCase):
                 EntityType.INVERTER,
                 EntityType.BATTERY_STORAGE,
                 EntityType.SOLAR_PANEL,
-                EntityType.EV_CHARGER):
+                EntityType.EV_CHARGER,
+                EntityType.MOTOR,
+                EntityType.PUMP,
+                EntityType.SUMP_PUMP):
             self.assertEqual(
                 EntityGroupType.from_entity_type(et),
                 EntityGroupType.ELECTRICAL,
@@ -185,10 +190,12 @@ class TestEntityGroupTypeAssignments(BaseTestCase):
                 msg=f'{et.name} expected in OUTDOORS',
             )
 
-    def test_structural_carries_doors_windows_and_walls(self):
-        # The garage split: GARAGE_DOOR is structural; the
-        # opener is in AUTOMATION.
+    def test_structural_carries_built_in_structure(self):
+        # The garage split: GARAGE_DOOR is structural; the opener
+        # is in AUTOMATION. AREA lives here because an "area" in
+        # HI is a spatial region of the home — structural by nature.
         for et in (
+                EntityType.AREA,
                 EntityType.DOOR,
                 EntityType.GARAGE_DOOR,
                 EntityType.WINDOW,
@@ -202,17 +209,14 @@ class TestEntityGroupTypeAssignments(BaseTestCase):
                 msg=f'{et.name} expected in STRUCTURAL',
             )
 
-    def test_general_catches_singletons_and_orphan_machinery(self):
-        # GENERAL replaces the old AREAS / AUTO / CONSUMABLES
-        # singletons and absorbs generic pumps/motors that
-        # don't fit a domain bucket.
+    def test_general_is_the_named_catchall(self):
+        # GENERAL is the named catchall — every EntityType is
+        # explicitly assigned, so there's no silent fallback
+        # bucket. EntityType.OTHER lives here too.
         for et in (
-                EntityType.AREA,
                 EntityType.AUTOMOBILE,
                 EntityType.CONSUMABLE,
-                EntityType.PUMP,
-                EntityType.MOTOR,
-                EntityType.SUMP_PUMP):
+                EntityType.OTHER):
             self.assertEqual(
                 EntityGroupType.from_entity_type(et),
                 EntityGroupType.GENERAL,
@@ -225,13 +229,12 @@ class TestEntityGroupTypeInvariants(BaseTestCase):
     bucket rebalance."""
 
     def test_every_entity_type_is_assigned_to_exactly_one_bucket(self):
-        """Full-coverage contract: every ``EntityType`` other than
-        ``EntityType.OTHER`` lives in exactly one non-``OTHER``
-        ``EntityGroupType``.
+        """Full-coverage contract: every ``EntityType`` is assigned
+        to exactly one ``EntityGroupType`` bucket.
 
-        This pins the no-silent-fallback contract. Adding a new
+        Pins the no-silent-fallback contract. Adding a new
         EntityType without assigning it to a bucket would silently
-        route it to OTHER under ``from_entity_type``; this test
+        route it to ``GENERAL`` via ``cls.default()``; this test
         forces the author to make an explicit assignment."""
         mapped: dict = {}
         for group in EntityGroupType:
@@ -252,26 +255,9 @@ class TestEntityGroupTypeInvariants(BaseTestCase):
                 msg=(
                     f'{entity_type.name} is not assigned to any '
                     f'EntityGroupType — every leaf type must have '
-                    f'an explicit bucket (no silent OTHER fallback)'
+                    f'an explicit bucket (no silent GENERAL fallback)'
                 ),
             )
-
-            assigned_bucket = mapped[entity_type]
-            if entity_type is EntityType.OTHER:
-                self.assertEqual(
-                    assigned_bucket, EntityGroupType.OTHER.name,
-                    msg='EntityType.OTHER must live in EntityGroupType.OTHER',
-                )
-            else:
-                self.assertNotEqual(
-                    assigned_bucket, EntityGroupType.OTHER.name,
-                    msg=(
-                        f'{entity_type.name} was assigned to OTHER; the '
-                        f'OTHER bucket is reserved for EntityType.OTHER '
-                        f'only. Use GENERAL for known-but-uncategorizable '
-                        f'types.'
-                    ),
-                )
 
     def test_from_entity_type_resolves_consistently_with_membership(self):
         # The lookup function must agree with the entity_type_set
@@ -283,8 +269,8 @@ class TestEntityGroupTypeInvariants(BaseTestCase):
                     group,
                 )
 
-    def test_default_returns_other(self):
-        self.assertEqual(EntityGroupType.default(), EntityGroupType.OTHER)
+    def test_default_returns_general(self):
+        self.assertEqual(EntityGroupType.default(), EntityGroupType.GENERAL)
 
 
 class TestEntityGroupTypeLabels(BaseTestCase):
@@ -313,7 +299,6 @@ class TestEntityGroupTypeLabels(BaseTestCase):
             EntityGroupType.ELECTRICAL: 'Electrical',
             EntityGroupType.FIXTURES: 'Fixtures',
             EntityGroupType.GENERAL: 'General',
-            EntityGroupType.OTHER: 'Other',
             EntityGroupType.OUTDOORS: 'Outdoors',
             EntityGroupType.POOL: 'Pool',
             EntityGroupType.SECURITY: 'Security',

--- a/src/hi/apps/location/edit/views.py
+++ b/src/hi/apps/location/edit/views.py
@@ -422,6 +422,7 @@ class LocationViewManageItemsView( HiSideView ):
         entity_view_group_list = EntityManager().create_location_entity_view_group_list(
             location_view = location_view,
             unused_entity_ids = unused_entity_ids,
+            exclude_delegates = True,
         )
         collection_view_group = CollectionManager().create_location_collection_view_group(
             location_view = location_view,


### PR DESCRIPTION
## Pull Request: Rebalance EntityGroupType buckets + hide delegates from edit sidebar (#367)

### Issue Link
Closes #367

---

## Category
- [x] **Refactor** (Code improvements without changing functionality)

---

## Changes Summary

**EntityGroupType bucket rebalance.** The prior bucket layout silently routed 18 EntityTypes (15% of all types) through the `OTHER` fallback because they had no explicit assignment — a freezer in "Other", a leak sensor in "Other", every pool entity in "Other", and so on. The layout also conflated heterogeneous types (`OUTDOORS` mixed irrigation hardware with vegetation with outdoor power tools; `UTILITIES` mixed electrical/plumbing/telecom; `LIGHTS_SWITCHES` bundled three orthogonal concepts).

New layout is **14 buckets** organized by how a homeowner partitions their LocationView floor plans and CollectionViews:

- `AUTOMATION` — controllable end-points (lights, outlets, switches, locks, garage opener, controllers).
- `SECURITY` — cameras, alarm-style sensors (smoke / CO / gas / leak / radon detectors), motion / open-close / presence sensors.
- `SENSORS` (new) — measurement / information sources (barometer, thermometer, hygrometer, light sensor, time/weather sources).
- `APPLIANCES` — now subsumes HVAC + water treatment alongside kitchen/laundry appliances.
- `POOL` (new) — dedicated bucket for pool equipment.
- `STRUCTURAL` — doors, windows, attic stairs, walls, fireplace, and `AREA`.
- `ELECTRICAL` — in-home electrical distribution (panels, wires, generators, solar, batteries, EV charger) plus pumps/motors.
- `UTILITIES` — incoming utility services (meters, supply lines, telecom inflow).
- `GENERAL` — explicit catchall for genuinely uncategorizable types (`AUTOMOBILE`, `CONSUMABLE`, `EntityType.OTHER`). Replaces the prior silent `OTHER` bucket.

Retired buckets: `LIGHTS_SWITCHES`, `CLIMATE`, `COMPUTER_NETWORK` (→ `COMPUTERS`), `TIME_WEATHER`, `AREAS`, `AUTO`, `CONSUMABLES`, `OTHER`.

A new **full-coverage invariant test** ensures every EntityType is explicitly assigned to exactly one bucket — adding a new EntityType without a bucket assignment will fail loudly in CI rather than silently routing to the catchall.

**Hide delegate entities from the edit-mode sidebar.** Placing a principal entity automatically pulls its delegates along (and unplacing removes them); surfacing the delegates as separately-toggleable rows in the same sidebar invited confusing partial states. `EntityManager.create_location_entity_view_group_list` and `CollectionManager.create_entity_collection_group_list` now accept an `exclude_delegates` kwarg; the two manage-items sidebars opt in. The entity-pairing modal keeps the default and continues to surface delegates so the relationship can be broken there.

**Developer doc.** Added a step to [`docs/dev/frontend/entity-visual-configuration.md`](docs/dev/frontend/entity-visual-configuration.md) calling out the EntityGroupType assignment requirement when adding a new EntityType.

---

## How to Test

1. `make lint` clean; `make test` green (3234 tests).
2. Open the entity-editing sidebar on a LocationView in edit mode — confirm the new bucket names appear, previously-"Other" items (freezer, leak sensor, pool equipment, garage door, etc.) now appear in their proper home, and delegate entities (Areas proxying for motion sensors, etc.) no longer appear as separately-toggleable rows.
3. Same check on the collection-editing sidebar.
4. Open the entity-pairing modal for a principal entity — delegate candidates remain visible there (filter does not apply).
5. Run HomeBox import against the simulator and open the placement modal — the default grouping (via `IntegrationGateway.group_entities_for_placement`, currently leaf-type) is unchanged in this PR; switching it to use `EntityGroupType` rollup is the follow-up issue #368.

---

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable.
- [x] No breaking changes introduced.

---

## Related PRs

- #366 — placement-grouping framework (#364), which set the stage for surfacing `EntityGroupType` more prominently.
- Follows-up: #368 (switch placement default to use `EntityGroupType.from_entity_type` rollup).

---

## Screenshots (if applicable)

---

## Additional Notes

- "Area as delegate" is a known design nuance flagged for future thought — Areas frequently act as delegates of security sensors. With this PR they're hidden from the edit sidebar when in a delegate relationship; the user manages the relationship through the pairing modal.
- The delegate filter is gated by an explicit kwarg defaulting to `False`, so future callers of the manager methods don't pick up the filter accidentally.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.

---

### **Reviewer(s)**
@cassandra
