### PR TITLE
[Tweak] Normalize icon sizes — drop misplaced size="sm"

### DIFF
--- a/src/hi/apps/alert/templates/alert/modals/alert_details.html
+++ b/src/hi/apps/alert/templates/alert/modals/alert_details.html
@@ -57,7 +57,7 @@
     <div class="card">
       <div class="card-header bg-primary text-white">
         <h6 class="mb-0">
-          {% icon "camera" size="sm" css_class="hi-icon-left" %}Video
+          {% icon "camera" css_class="hi-icon-left" %}Video
         </h6>
       </div>
       <div class="card-body p-2">
@@ -84,7 +84,7 @@
     <div class="card">
       <div class="card-header bg-primary text-white">
         <h6 class="mb-0">
-          {% icon "camera" size="sm" css_class="hi-icon-left" %}Image
+          {% icon "camera" css_class="hi-icon-left" %}Image
         </h6>
       </div>
       <div class="card-body p-2">
@@ -106,8 +106,8 @@
         <h6 class="mb-0">
           <a class="text-white text-decoration-none" data-toggle="collapse" href="#videoSources" 
              role="button" aria-expanded="false" aria-controls="videoSources">
-            {% icon "camera" size="sm" css_class="hi-icon-left" %}Video Sources ({{ video_source_count }})
-            {% icon "play" size="sm" css_class="hi-icon-right" %}
+            {% icon "camera" css_class="hi-icon-left" %}Video Sources ({{ video_source_count }})
+            {% icon "play" css_class="hi-icon-right" %}
           </a>
         </h6>
       </div>
@@ -179,7 +179,7 @@
         <h6 class="mb-0">
           <a class="text-decoration-none" data-toggle="collapse" href="#additionalAlarms" 
              role="button" aria-expanded="false" aria-controls="additionalAlarms">
-            {% icon "play" size="sm" css_class="hi-icon-left" %}Previous Alarms ({{ alert.alarm_count|add:"-1" }})
+            {% icon "play" css_class="hi-icon-left" %}Previous Alarms ({{ alert.alarm_count|add:"-1" }})
           </a>
         </h6>
       </div>

--- a/src/hi/apps/alert/templates/alert/panes/alarm_sensor_response.html
+++ b/src/hi/apps/alert/templates/alert/panes/alarm_sensor_response.html
@@ -36,7 +36,7 @@
         <small>
           <a href="{% url 'console_entity_video_sensor_history' entity_id=sensor_response.sensor.entity_state.entity.id sensor_id=sensor_response.sensor.id %}"
              data-async="true" class="text-muted">
-            {% icon "video" size="sm" css_class="hi-icon-left" %}Browse Video Timeline
+            {% icon "video" css_class="hi-icon-left" %}Browse Video Timeline
           </a>
         </small>
       </div>

--- a/src/hi/apps/attribute/templates/attribute/components/edit_content_body.html
+++ b/src/hi/apps/attribute/templates/attribute/components/edit_content_body.html
@@ -51,12 +51,12 @@ by using the AttributeItemEditContext pattern.
                 class="btn btn-outline-primary d-inline-flex align-items-center {{ DIVID.ATTR_V2_UPDATE_BTN_CLASS }}"
                 name="action"
                 value="update">
-          {% icon "save" size="sm" css_class="hi-icon-left" %}
+          {% icon "save" css_class="hi-icon-left" %}
           {{ attr_page_context.update_button_label }}
         </button>
         {% elif attr_page_context.externally_managed_message %}
         <div class="attr-v2-externally-managed text-muted small d-inline-flex align-items-center">
-          {% icon "info-circle" size="sm" css_class="hi-icon-left" %}
+          {% icon "info-circle" css_class="hi-icon-left" %}
           {{ attr_page_context.externally_managed_message }}
         </div>
         {% endif %}

--- a/src/hi/apps/attribute/templates/attribute/components/regular_attribute_card.html
+++ b/src/hi/apps/attribute/templates/attribute/components/regular_attribute_card.html
@@ -57,7 +57,7 @@ Individual attribute attribute card with value editing and actions
       
     {% else %}
       <h6 class="{{ DIVID.ATTR_V2_ATTRIBUTE_NAME_CLASS }}">
-        {% icon "plus" size="sm" css_class="hi-icon-left" %}Add New
+        {% icon "plus" css_class="hi-icon-left" %}Add New
       </h6>
     {% endif %}
 
@@ -116,7 +116,7 @@ Individual attribute attribute card with value editing and actions
                 class="{{ DIVID.ATTR_V2_DELETE_BTN_CLASS }}"
                 title="Delete attribute"
                 onclick="markAttributeForDeletion('{{ attribute_form.instance.pk }}', '#{{ attr_page_context.container_html_id }}')" >
-          {% icon "delete" size="sm" %}
+          {% icon "delete" %}
         </button>
         <button type="button" 
                 class="btn btn-sm btn-outline-warning {{ DIVID.ATTR_V2_UNDO_BTN_CLASS }}"

--- a/src/hi/apps/console/templates/console/modals/console_unlock.html
+++ b/src/hi/apps/console/templates/console/modals/console_unlock.html
@@ -17,7 +17,7 @@
   {% block action_center %}
   <button id="hi-console-unlock-button" type="submit" class="btn btn-lg btn-primary"
         name="action" value="unlock">
-    {% icon "unlock" size="sm" css_class="hi-icon-left" %}UNLOCK
+    {% icon "unlock" css_class="hi-icon-left" %}UNLOCK
   </button>
   {% endblock %}
 

--- a/src/hi/apps/console/templates/console/modals/set_lock_password.html
+++ b/src/hi/apps/console/templates/console/modals/set_lock_password.html
@@ -20,7 +20,7 @@
   {% block action_center %}
   <button id="hi-console-set-lock-password-button" type="submit" class="btn btn-lg btn-primary"
         name="action" value="set">
-    {% icon "unlock" size="sm" css_class="hi-icon-left" %}SET PASSWORD
+    {% icon "unlock" css_class="hi-icon-left" %}SET PASSWORD
   </button>
   {% endblock %}
 

--- a/src/hi/apps/console/templates/console/panes/audio_control.html
+++ b/src/hi/apps/console/templates/console/panes/audio_control.html
@@ -6,7 +6,7 @@
           class="btn btn-primary btn-control" 
           onclick="Hi.audio.handleAudioButtonClick();"  
           title="Sounds enabled. Tap to Disable">
-    {% icon "audio-enabled" size="sm" css_class="hi-icon-left" %}Sounds: On
+    {% icon "audio-enabled" css_class="hi-icon-left" %}Sounds: On
   </button>
   <button id="hi-audio-state-disabled" 
           role="button"
@@ -14,7 +14,7 @@
           class="btn btn-secondary btn-control"
           onclick="Hi.audio.handleAudioButtonClick();"  
           title="Sounds disabled. Tap to enable">
-    {% icon "audio-disabled" size="sm" css_class="hi-icon-left" %}Sounds: Off
+    {% icon "audio-disabled" css_class="hi-icon-left" %}Sounds: Off
   </button>
   <button id="hi-audio-state-blocked" 
           role="button"
@@ -22,6 +22,6 @@
           class="btn btn-danger btn-control"
           onclick="Hi.audio.handleAudioButtonClick();"  
           title="Browser blocked audio. Click for help">
-    {% icon "exclamation-circle" size="sm" css_class="hi-icon-left" %}Sounds: Blocked
+    {% icon "exclamation-circle" css_class="hi-icon-left" %}Sounds: Blocked
   </button>
 </div>

--- a/src/hi/apps/console/templates/console/panes/console_lock_button.html
+++ b/src/hi/apps/console/templates/console/panes/console_lock_button.html
@@ -5,7 +5,7 @@
     <button type="submit" id="hi-console-lock-button" role="button"
             class="btn btn-primary btn-control"
             title="Console Unlocked. Tap to Lock">
-      {% icon "lock" size="sm" css_class="hi-icon-left" %}LOCK
+      {% icon "lock" css_class="hi-icon-left" %}LOCK
     </button>
   </form>
 </div>

--- a/src/hi/apps/console/templates/console/panes/entity_video_pane.html
+++ b/src/hi/apps/console/templates/console/panes/entity_video_pane.html
@@ -10,7 +10,7 @@
             <div class="video-nav-tabs" role="tablist">
                 {% if entity.has_live_view %}
                 <span class="video-nav-tab active" role="tab">
-                    {% icon "video" size="sm" css_class="hi-icon-left" %}{% if entity.has_live_feed %}Live Stream{% else %}Snapshot{% endif %}
+                    {% icon "video" css_class="hi-icon-left" %}{% if entity.has_live_feed %}Live Stream{% else %}Snapshot{% endif %}
                 </span>
                 {% endif %}
                 {% if video_sensor %}
@@ -19,7 +19,7 @@
                    data-async="#main-content"
                    onclick="sessionStorage.setItem('navigatingFromLiveStream', 'true');"
                    role="tab">
-                    {% icon "history" size="sm" css_class="hi-icon-left" %}Event History
+                    {% icon "history" css_class="hi-icon-left" %}Event History
                 </a>
                 {% endif %}
             </div>

--- a/src/hi/apps/console/templates/console/panes/entity_video_sensor_history.html
+++ b/src/hi/apps/console/templates/console/panes/entity_video_sensor_history.html
@@ -17,10 +17,10 @@
                    data-async="#main-content"
                    aria-label="Return to live camera stream"
                    role="tab">
-                    {% icon "video" size="sm" css_class="hi-icon-left" %}Current Stream
+                    {% icon "video" css_class="hi-icon-left" %}Current Stream
                 </a>
                 <span class="video-nav-tab active" role="tab">
-                    {% icon "history" size="sm" css_class="hi-icon-left" %}Event History
+                    {% icon "history" css_class="hi-icon-left" %}Event History
                 </span>
             </div>
         </div>

--- a/src/hi/apps/console/templates/console/panes/hi_grid_side.html
+++ b/src/hi/apps/console/templates/console/panes/hi_grid_side.html
@@ -16,7 +16,7 @@
       {% include "security/panes/security_state_control.html" %}
     </div>
   </div>
-  <div class="my-2">
+  <div class="m-2">
     <a href="{% url 'event_history' %}"
        class="btn btn-outline-primary btn-control" role="button"
        data-async="true" >

--- a/src/hi/apps/console/templates/console/panes/sleep_mode_control.html
+++ b/src/hi/apps/console/templates/console/panes/sleep_mode_control.html
@@ -1,5 +1,5 @@
 {% load icons %}
 <button class="btn btn-primary btn-control" role="button"
 onclick="Hi.settings.enableSleepMode();">
-  {% icon "sleep" size="sm" css_class="hi-icon-left" %}SLEEP
+  {% icon "sleep" css_class="hi-icon-left" %}SLEEP
 </button>

--- a/src/hi/apps/console/templates/console/panes/video_clip_replay_button.html
+++ b/src/hi/apps/console/templates/console/panes/video_clip_replay_button.html
@@ -7,5 +7,5 @@
 {# img's URL to play the clip from the start.                   #}
 <button type="button" class="hi-video-clip-replay"
         title="Replay from start" aria-label="Replay from start">
-  {% icon "rotate" size="sm" %}
+  {% icon "rotate" %}
 </button>

--- a/src/hi/apps/control/templates/control/panes/controller_data.html
+++ b/src/hi/apps/control/templates/control/panes/controller_data.html
@@ -11,7 +11,7 @@
     {% if controller_data.error_list %}
     <div class="alert alert-danger d-flex align-items-start mt-2 py-2 small"
          role="alert">
-      {% icon "warning" size="sm" css_class="mr-2 mt-1" %}
+      {% icon "warning" css_class="mr-2 mt-1" %}
       <div>
         {% for msg in controller_data.error_list %}
         <div>{{ msg }}</div>

--- a/src/hi/apps/edit/templates/edit/panes/entity_picker.html
+++ b/src/hi/apps/edit/templates/edit/panes/entity_picker.html
@@ -12,7 +12,7 @@
         <a href="{% url 'entity_edit_entity_add' %}"
            class="btn btn-add btn-block btn-control" role="button"
            data-async="modal">
-          {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD NEW ITEM
+          {% icon "plus" css_class="hi-icon-left" %}ADD NEW ITEM
         </a>
       </div>
 
@@ -25,7 +25,7 @@
             <button type="button"
                     class="btn btn-outline-secondary {{ DIVID.ENTITY_PICKER_SEARCH_CLEAR_CLASS }}"
                     title="Clear search">
-              {% icon "close" size="sm" %}
+              {% icon "close" %}
             </button>
           </div>
         </div>

--- a/src/hi/apps/entity/templates/entity/edit/modals/entity_add.html
+++ b/src/hi/apps/entity/templates/entity/edit/modals/entity_add.html
@@ -20,7 +20,7 @@ New Item
 {% block action_right %}
 <button id="hi-add-entity-button" type="submit" class="btn btn-primary"
         name="action" value="add">
-  {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD
+  {% icon "plus" css_class="hi-icon-left" %}ADD
 </button>
 {% endblock %}
 

--- a/src/hi/apps/entity/templates/entity/edit/panes/entity_properties_edit.html
+++ b/src/hi/apps/entity/templates/entity/edit/panes/entity_properties_edit.html
@@ -11,7 +11,7 @@
   <div class="text-center" >
     <button id="hi-entity-properties-edit-button" type="submit" class="btn btn-primary btn-block"
             name="action" value="update" disabled>
-      {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+      {% icon "save" css_class="hi-icon-left" %}UPDATE
     </button>
   </div>
 </form>

--- a/src/hi/apps/entity/templates/entity/modals/entity_edit.html
+++ b/src/hi/apps/entity/templates/entity/modals/entity_edit.html
@@ -55,7 +55,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_status' entity_id=entity.id %}"
    data-async="modal">
-  {% icon "info-circle" size="sm" css_class="hi-icon-left" %}STATUS
+  {% icon "info-circle" css_class="hi-icon-left" %}STATUS
 </a>
 {% endblock %}
 
@@ -63,7 +63,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_history' entity_id=entity.id %}"
    data-async="modal">
-  {% icon "history" size="sm" css_class="hi-icon-left" %}HISTORY
+  {% icon "history" css_class="hi-icon-left" %}HISTORY
 </a>
 {% endblock %}
 

--- a/src/hi/apps/entity/templates/entity/modals/entity_history.html
+++ b/src/hi/apps/entity/templates/entity/modals/entity_history.html
@@ -40,7 +40,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_edit' entity_id=entity.id %}"
    data-async="modal">
-  {% icon "edit" size="sm" css_class="hi-icon-left" %}EDIT
+  {% icon "edit" css_class="hi-icon-left" %}EDIT
 </a>
 {% endblock %}
 
@@ -48,7 +48,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_status' entity_id=entity.id %}"
    data-async="modal">
-  {% icon "info-circle" size="sm" css_class="hi-icon-left" %}STATUS
+  {% icon "info-circle" css_class="hi-icon-left" %}STATUS
 </a>
 {% endblock %}
 

--- a/src/hi/apps/entity/templates/entity/modals/entity_state_history.html
+++ b/src/hi/apps/entity/templates/entity/modals/entity_state_history.html
@@ -39,7 +39,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_edit' entity_id=entity_state.entity.id %}"
    data-async="modal">
-  {% icon "edit" size="sm" css_class="hi-icon-left" %}EDIT
+  {% icon "edit" css_class="hi-icon-left" %}EDIT
 </a>
 {% endblock %}
 
@@ -47,7 +47,7 @@
 <a class="btn btn-primary"
    href="{% url 'entity_status' entity_id=entity_state.entity.id %}"
    data-async="modal">
-  {% icon "info-circle" size="sm" css_class="hi-icon-left" %}STATUS
+  {% icon "info-circle" css_class="hi-icon-left" %}STATUS
 </a>
 {% endblock %}
 

--- a/src/hi/apps/entity/templates/entity/modals/entity_status.html
+++ b/src/hi/apps/entity/templates/entity/modals/entity_status.html
@@ -31,7 +31,7 @@ Panel dispatch trace:
 <a class="btn btn-primary"
    href="{% url 'entity_edit' entity_id=state_panel_data.entity.id %}"
    data-async="modal">
-  {% icon "edit" size="sm" css_class="hi-icon-left" %}EDIT
+  {% icon "edit" css_class="hi-icon-left" %}EDIT
 </a>
 {% endblock %}
 
@@ -39,7 +39,7 @@ Panel dispatch trace:
 <a class="btn btn-primary"
    href="{% url 'entity_history' entity_id=state_panel_data.entity.id %}"
    data-async="modal">
-  {% icon "history" size="sm" css_class="hi-icon-left" %}HISTORY
+  {% icon "history" css_class="hi-icon-left" %}HISTORY
 </a>
 {% endblock %}
 

--- a/src/hi/apps/entity/templates/entity/panes/entity_edit_content_body.html
+++ b/src/hi/apps/entity/templates/entity/panes/entity_edit_content_body.html
@@ -86,7 +86,7 @@ Extends the generic attribute edit content body with entity-specific field layou
      data-toggle="tab"
      href="#hi-attr-tab3-{{ attr_item_context.owner_id }}"
      role="tab">
-    {% icon "link" size="sm" css_class="hi-icon-left" %}Linked Content
+    {% icon "link" css_class="hi-icon-left" %}Linked Content
   </a>
 </li>
 {% endif %}

--- a/src/hi/apps/event/templates/event/edit/modals/event_definition_add.html
+++ b/src/hi/apps/event/templates/event/edit/modals/event_definition_add.html
@@ -23,7 +23,7 @@ New Rule
 {% block action_right %}
 <button id="hi-add-event-definition-button" type="submit" class="btn btn-primary"
         name="action" value="add">
-  {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD
+  {% icon "plus" css_class="hi-icon-left" %}ADD
 </button>
 {% endblock %}
 

--- a/src/hi/apps/event/templates/event/edit/modals/event_definition_delete.html
+++ b/src/hi/apps/event/templates/event/edit/modals/event_definition_delete.html
@@ -52,7 +52,7 @@ Please confirm that you want to delete this rule.
 {% block action_right %}
 <button id="hi-delete-event-definition-button" type="submit" class="btn btn-danger"
         name="action" value="delete">
-  {% icon "delete" size="sm" css_class="hi-icon-left" %}DELETE
+  {% icon "delete" css_class="hi-icon-left" %}DELETE
 </button>
 {% endblock %}
 

--- a/src/hi/apps/event/templates/event/edit/modals/event_definition_edit.html
+++ b/src/hi/apps/event/templates/event/edit/modals/event_definition_edit.html
@@ -23,7 +23,7 @@ Edit Rule
 {% block action_right %}
 <button id="hi-edit-event-definition-button" type="submit" class="btn btn-primary"
         name="action" value="edit">
-  {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+  {% icon "save" css_class="hi-icon-left" %}UPDATE
 </button>
 {% endblock %}
 

--- a/src/hi/apps/event/templates/event/modals/event_history.html
+++ b/src/hi/apps/event/templates/event/modals/event_history.html
@@ -12,7 +12,7 @@ Rule Matches
   <div class="row mb-3">
     <div class="col-12">
       <h5 class="mb-0">
-        {% icon "history" size="sm" color="primary" css_class="hi-icon-left" %}
+        {% icon "history" color="primary" css_class="hi-icon-left" %}
         Rule Matches
       </h5>
       <small class="text-muted">Recent rule matches and their details</small>

--- a/src/hi/apps/event/templates/event/panes/event_definitions.html
+++ b/src/hi/apps/event/templates/event/panes/event_definitions.html
@@ -12,7 +12,7 @@
       <a role="button" class="btn btn-outline-primary"
          href="{% url 'event_definition_add' %}"
          data-async="modal" >
-        {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD NEW RULE
+        {% icon "plus" css_class="hi-icon-left" %}ADD NEW RULE
       </a>
     </div>
   </div>

--- a/src/hi/apps/location/templates/location/edit/modals/location_add.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_add.html
@@ -20,7 +20,7 @@ New Space
 {% block action_right %}
 <button id="hi-add-location-button" type="submit" class="btn btn-primary"
         name="action" value="add">
-  {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD
+  {% icon "plus" css_class="hi-icon-left" %}ADD
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_add_first.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_add_first.html
@@ -20,7 +20,7 @@ Create Your Space
 {% block action_right %}
 <button id="hi-add-location-button" type="submit" class="btn btn-primary"
         name="action" value="add">
-  {% icon "plus" size="sm" css_class="hi-icon-left" %}CREATE
+  {% icon "plus" css_class="hi-icon-left" %}CREATE
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_delete.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_delete.html
@@ -26,7 +26,7 @@ Delete Space?
   {% csrf_token %}
   <button id="hi-delete-location-button" type="submit" class="btn btn-danger"
           name="action" value="confirm">
-    {% icon "delete" size="sm" css_class="hi-icon-left" %}DELETE
+    {% icon "delete" css_class="hi-icon-left" %}DELETE
   </button>
 </form>
 {% endblock %}

--- a/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_cancel.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_cancel.html
@@ -21,7 +21,7 @@ Discard Changes?
 
 {% block action_right %}
 <button id="hi-location-svg-edit-cancel-button" type="submit" class="btn btn-danger">
-  {% icon "delete" size="sm" css_class="hi-icon-left" %}DISCARD CHANGES
+  {% icon "delete" css_class="hi-icon-left" %}DISCARD CHANGES
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_exit.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_exit.html
@@ -21,7 +21,7 @@ Save Space Background?
 
 {% block action_right %}
 <button id="hi-location-svg-edit-exit-button" type="submit" class="btn btn-primary">
-  {% icon "save" size="sm" css_class="hi-icon-left" %}SAVE CHANGES
+  {% icon "save" css_class="hi-icon-left" %}SAVE CHANGES
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_help.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_help.html
@@ -20,7 +20,7 @@ Background Editor Help
         <div class="help-category">
             <div class="category-header">
                 <div class="category-icon">
-                    {% icon "move" size="sm" color="primary" %}
+                    {% icon "move" color="primary" %}
                 </div>
                 <h6 class="category-title">General</h6>
             </div>
@@ -56,7 +56,7 @@ Background Editor Help
         <div class="help-category">
             <div class="category-header">
                 <div class="category-icon">
-                    {% icon "zoom" size="sm" color="primary" %}
+                    {% icon "zoom" color="primary" %}
                 </div>
                 <h6 class="category-title">Icon Editing</h6>
             </div>
@@ -96,7 +96,7 @@ Background Editor Help
         <div class="help-category help-category-wide">
             <div class="category-header">
                 <div class="category-icon">
-                    {% icon "path" size="sm" color="primary" %}
+                    {% icon "path" color="primary" %}
                 </div>
                 <h6 class="category-title">Path Editing</h6>
             </div>

--- a/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_revert.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_svg_edit_revert.html
@@ -20,7 +20,7 @@ Revert All Changes?
 
 {% block action_right %}
 <button id="hi-location-svg-edit-revert-button" type="submit" class="btn btn-danger">
-  {% icon "undo" size="sm" css_class="hi-icon-left" %}REVERT
+  {% icon "undo" css_class="hi-icon-left" %}REVERT
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_svg_replace.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_svg_replace.html
@@ -21,7 +21,7 @@ Replace Space Background
 {% block action_right %}
 <button id="hi-svg-replace-button" type="submit" class="btn btn-primary"
         name="action" value="replace">
-  {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+  {% icon "save" css_class="hi-icon-left" %}UPDATE
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_view_add.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_view_add.html
@@ -20,7 +20,7 @@ New View for {{ location.name }}
 {% block action_right %}
 <button id="hi-add-location-view-button" type="submit" class="btn btn-primary"
         name="action" value="add">
-  {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD
+  {% icon "plus" css_class="hi-icon-left" %}ADD
 </button>
 {% endblock %}
 

--- a/src/hi/apps/location/templates/location/edit/modals/location_view_delete.html
+++ b/src/hi/apps/location/templates/location/edit/modals/location_view_delete.html
@@ -26,7 +26,7 @@ Delete View?
   {% csrf_token %}
   <button id="hi-delete-location-view-button" type="submit" class="btn btn-danger"
           name="action" value="confirm">
-    {% icon "delete" size="sm" css_class="hi-icon-left" %}DELETE
+    {% icon "delete" css_class="hi-icon-left" %}DELETE
   </button>
 </form>
 {% endblock %}

--- a/src/hi/apps/location/templates/location/edit/pages/location_svg_edit.html
+++ b/src/hi/apps/location/templates/location/edit/pages/location_svg_edit.html
@@ -18,12 +18,12 @@
       <a href="{% url 'location_svg_edit_cancel' location_id=location.id %}"
          id="hi-location-svg-edit-cancel-link" class="btn btn-outline-tertiary mx-1" role="button"
          data-async="true">
-        {% icon "delete" size="sm" css_class="hi-icon-left" %}DISCARD
+        {% icon "delete" css_class="hi-icon-left" %}DISCARD
       </a>
       <a href="{% url 'location_svg_edit_exit' location_id=location.id %}"
          id="hi-location-svg-edit-exit-link" class="btn btn-primary mx-1" role="button"
          data-async="true">
-        {% icon "save" size="sm" css_class="hi-icon-left" %}DONE
+        {% icon "save" css_class="hi-icon-left" %}DONE
       </a>
     </div>
   </div>
@@ -70,7 +70,7 @@
       <a href="{% url 'location_svg_edit_help' %}"
          class="btn btn-tertiary text-nowrap mx-1" role="button"
          data-async="true">
-        {% icon "question-circle" size="sm" css_class="hi-icon-left" %}HELP
+        {% icon "question-circle" css_class="hi-icon-left" %}HELP
       </a>
     </div>
   </div>
@@ -80,13 +80,13 @@
      style="margin-top: var(--svg-editor-top-height);">
   {% if draft_resumed %}
   <div class="alert alert-info alert-dismissible fade show m-0 py-1 px-3 rounded-0" role="alert" style="font-size: 0.85rem;">
-    {% icon "info-circle" size="sm" css_class="hi-icon-left" %}
+    {% icon "info-circle" css_class="hi-icon-left" %}
     Resumed draft from previous session. Use CANCEL to discard.
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   </div>
   {% endif %}
   <div id="{{ DIVID.LOCATION_SVG_EDIT_CONFORMANCE_WARNING }}" class="alert alert-warning alert-dismissible fade show m-0 py-1 px-3 rounded-0" role="alert" style="font-size: 0.85rem; display: none;">
-    {% icon "warning" size="sm" css_class="hi-icon-left" %}
+    {% icon "warning" css_class="hi-icon-left" %}
     Not all elements in this background are editable. It contains some imported content. Only elements added in this editor are editable.
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   </div>

--- a/src/hi/apps/location/templates/location/edit/panes/location_edit_mode_panel.html
+++ b/src/hi/apps/location/templates/location/edit/panes/location_edit_mode_panel.html
@@ -12,7 +12,7 @@
   <a href="{% url 'location_svg_background' location_id=location.id %}"
      id="hi-svg-background-link" class="btn btn-outline-primary btn-block btn-control" role="button"
      data-async="true">
-    {% icon "layers" size="sm" css_class="hi-icon-left" %}BACKGROUND IMAGE
+    {% icon "layers" css_class="hi-icon-left" %}BACKGROUND IMAGE
   </a>
 </div>
 

--- a/src/hi/apps/location/templates/location/edit/panes/location_item_position_form.html
+++ b/src/hi/apps/location/templates/location/edit/panes/location_item_position_form.html
@@ -46,6 +46,6 @@
 <div class="sidebar-form-actions">
   <button id="hi-add-entity-edit-button" type="submit" class="btn btn-primary btn-block"
           name="action" value="update">
-    {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+    {% icon "save" css_class="hi-icon-left" %}UPDATE
   </button>
 </div>

--- a/src/hi/apps/location/templates/location/edit/panes/location_properties_edit.html
+++ b/src/hi/apps/location/templates/location/edit/panes/location_properties_edit.html
@@ -12,7 +12,7 @@
   <div class="sidebar-form-actions">
     <button id="hi-location-properties-edit-button" type="submit" class="btn btn-primary btn-block"
         name="action" value="update" disabled>
-      {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+      {% icon "save" css_class="hi-icon-left" %}UPDATE
     </button>
   </div>
 </form>

--- a/src/hi/apps/location/templates/location/edit/panes/location_view_properties_edit.html
+++ b/src/hi/apps/location/templates/location/edit/panes/location_view_properties_edit.html
@@ -11,7 +11,7 @@
   <div class="sidebar-form-actions">
     <button id="hi-add-location-view-button" type="submit" class="btn btn-primary btn-block"
             name="action" value="update" disabled>
-      {% icon "save" size="sm" css_class="hi-icon-left" %}UPDATE
+      {% icon "save" css_class="hi-icon-left" %}UPDATE
     </button>
   </div>
 </form>

--- a/src/hi/apps/location/templates/location/panes/location_dropdown.html
+++ b/src/hi/apps/location/templates/location/panes/location_dropdown.html
@@ -4,7 +4,7 @@
   <div class="dropdown">
     <button class="btn btn-outline-primary btn-control dropdown-toggle" type="button"
             id="hi-location-menu" data-toggle="dropdown">
-      {% icon "layers" size="sm" css_class="hi-icon-left" %}ALL SPACES
+      {% icon "layers" css_class="hi-icon-left" %}ALL SPACES
       <span class="caret"></span>
     </button>
     <div class="dropdown-menu"
@@ -14,7 +14,7 @@
          class="dropdown-item plain{% if location == request.view_parameters.location %} active{% endif %}"
          href="{% url 'location_switch' location_id=location.id %}">
         {% if location == request.view_parameters.location %}
-        {% icon "check-circle" size="sm" css_class="hi-icon-left" %}
+        {% icon "check-circle" css_class="hi-icon-left" %}
         {% endif %}
         {{ location.name }}
       </a>
@@ -28,7 +28,7 @@
       <a role="menuitem" class="dropdown-item dropdown-item-add"
          href="{% url 'location_edit_location_add' %}"
          data-async="modal">
-        {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD NEW SPACE
+        {% icon "plus" css_class="hi-icon-left" %}ADD NEW SPACE
       </a>
       {% endif %}
     </div>

--- a/src/hi/apps/location/templates/location/panes/location_edit_content_body.html
+++ b/src/hi/apps/location/templates/location/panes/location_edit_content_body.html
@@ -27,7 +27,7 @@ Extends the generic attribute edit content body with location-specific field lay
      data-toggle="tab"
      href="#hi-attr-tab3-{{ attr_item_context.owner_id }}"
      role="tab">
-    {% icon "link" size="sm" css_class="hi-icon-left" %}Linked Content
+    {% icon "link" css_class="hi-icon-left" %}Linked Content
   </a>
 </li>
 {% endif %}

--- a/src/hi/apps/profiles/templates/profiles/panes/edit_empty_help_sidebar.html
+++ b/src/hi/apps/profiles/templates/profiles/panes/edit_empty_help_sidebar.html
@@ -43,7 +43,7 @@
 
     <a class="plain" href="{% url 'profiles_edit_reference_help' %}" data-async="modal">
       <div class="help-hint">
-        {% icon "question-circle" size="sm" color="muted" %}
+        {% icon "question-circle" color="muted" %}
         <small>Use "Editing Help" below for layout tips</small>
       </div>
     </a>

--- a/src/hi/apps/profiles/templates/profiles/panes/edit_intro_help_header.html
+++ b/src/hi/apps/profiles/templates/profiles/panes/edit_intro_help_header.html
@@ -64,7 +64,7 @@
 
       <a class="plain" href="{% url 'profiles_edit_reference_help' %}" data-async="modal">
         <div class="help-hint">
-          {% icon "question-circle" size="sm" color="muted" %}
+          {% icon "question-circle" color="muted" %}
           <small>Use "Editing Help" below for layout tips</small>
         </div>
       </a>

--- a/src/hi/apps/profiles/templates/profiles/panes/view_intro_help_sidebar.html
+++ b/src/hi/apps/profiles/templates/profiles/panes/view_intro_help_sidebar.html
@@ -50,7 +50,7 @@
         
         <a class="plain" href="{% url 'profiles_view_reference_help' %}" data-async="modal">
           <div class="help-hint">
-            {% icon "question-circle" size="sm" color="muted" %}
+            {% icon "question-circle" color="muted" %}
             <small>Need more help with getting started?</small>
           </div>
         </a>

--- a/src/hi/apps/profiles/templates/profiles/tests/devtools/modals/snapshot_select.html
+++ b/src/hi/apps/profiles/templates/profiles/tests/devtools/modals/snapshot_select.html
@@ -48,7 +48,7 @@ Generate Profile Snapshot
 {% block action_right %}
 <button id="hi-generate-snapshot-button" type="submit" class="btn btn-success"
         name="action" value="generate">
-  {% icon "camera" size="sm" css_class="hi-icon-left" %}GENERATE
+  {% icon "camera" css_class="hi-icon-left" %}GENERATE
 </button>
 {% endblock %}
 

--- a/src/hi/apps/sense/templates/sense/modals/sensor_history_details.html
+++ b/src/hi/apps/sense/templates/sense/modals/sensor_history_details.html
@@ -57,7 +57,7 @@ Sensor Response Details
 <a class="btn btn-primary"
    href="{% url 'entity_status' entity_id=sensor_history.sensor.entity_state.entity.id %}"
    data-async="modal">
-  {% icon "info-circle" size="sm" css_class="hi-icon-left" %}STATUS
+  {% icon "info-circle" css_class="hi-icon-left" %}STATUS
 </a>
 {% endblock %}
 
@@ -65,7 +65,7 @@ Sensor Response Details
 <a class="btn btn-primary"
    href="{% url 'entity_history' entity_id=sensor_history.sensor.entity_state.entity.id %}"
    data-async="modal">
-  {% icon "history" size="sm" css_class="hi-icon-left" %}HISTORY
+  {% icon "history" css_class="hi-icon-left" %}HISTORY
 </a>
 {% endblock %}
 

--- a/src/hi/apps/system/templates/system/modals/background_task_status.html
+++ b/src/hi/apps/system/templates/system/modals/background_task_status.html
@@ -4,7 +4,7 @@
 {% block modal_dialog_class %}hi-modal-dialog-800{% endblock %}
 
 {% block title_text %}
-{% icon "tasks" size="sm" css_class="mr-2" %}
+{% icon "tasks" css_class="mr-2" %}
 Background Task Details
 {% endblock %}
 

--- a/src/hi/apps/system/templates/system/panes/api_health_status_details.html
+++ b/src/hi/apps/system/templates/system/panes/api_health_status_details.html
@@ -7,7 +7,7 @@
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h5 class="mb-0">{{ api_health_status.provider_name }}</h5>
     <span class="badge {{ api_health_status.status_badge_class }}">
-      {% icon api_health_status.status_icon size="sm" css_class="mr-1" %}{{ api_health_status.status.label }}
+      {% icon api_health_status.status_icon css_class="mr-1" %}{{ api_health_status.status.label }}
     </span>
   </div>
   

--- a/src/hi/apps/system/templates/system/panes/api_health_status_item.html
+++ b/src/hi/apps/system/templates/system/panes/api_health_status_item.html
@@ -12,7 +12,7 @@
       </div>
       <div>
         <span class="badge {{ api_health_status.status_badge_class }}">
-          {% icon api_health_status.status_icon size="sm" css_class="mr-1" %}{{ api_health_status.status_display }}
+          {% icon api_health_status.status_icon css_class="mr-1" %}{{ api_health_status.status_display }}
         </span>
       </div>
     </div>

--- a/src/hi/apps/system/templates/system/panes/background_task_details.html
+++ b/src/hi/apps/system/templates/system/panes/background_task_details.html
@@ -27,11 +27,11 @@
           <div class="col-sm-9">
             {% if task_info.thread.is_alive %}
             <span class="text-success">
-              {% icon "check-circle" size="sm" css_class="mr-1" %}{{ task_info.thread_name }}
+              {% icon "check-circle" css_class="mr-1" %}{{ task_info.thread_name }}
             </span>
             {% else %}
             <span class="text-danger">
-              {% icon "warning" size="sm" css_class="mr-1" %}Dead
+              {% icon "warning" css_class="mr-1" %}Dead
             </span>
             {% endif %}
           </div>
@@ -42,15 +42,15 @@
           <div class="col-sm-9">
             {% if task_info.event_loop.exists and task_info.event_loop.is_running %}
             <span class="text-success">
-              {% icon "check-circle" size="sm" css_class="mr-1" %}Running ({{ task_info.event_loop.active_tasks }} active tasks)
+              {% icon "check-circle" css_class="mr-1" %}Running ({{ task_info.event_loop.active_tasks }} active tasks)
             </span>
             {% elif task_info.event_loop.exists %}
             <span class="text-warning">
-              {% icon "warning" size="sm" css_class="mr-1" %}Stopped
+              {% icon "warning" css_class="mr-1" %}Stopped
             </span>
             {% else %}
             <span class="text-danger">
-              {% icon "warning" size="sm" css_class="mr-1" %}Dead
+              {% icon "warning" css_class="mr-1" %}Dead
             </span>
             {% endif %}
           </div>

--- a/src/hi/apps/system/templates/system/panes/health_status_card.html
+++ b/src/hi/apps/system/templates/system/panes/health_status_card.html
@@ -16,7 +16,7 @@
       <div class="d-flex justify-content-between align-items-center mb-2">
       <h6 class="mb-0">{{ health_status.provider_name }}</h6>
       <span class="badge monitor-status-badge {{ health_status.status_badge_class }}">
-        {% icon health_status.status_icon size="sm" css_class="mr-1" %}{{ health_status.status_display }}
+        {% icon health_status.status_icon css_class="mr-1" %}{{ health_status.status_display }}
       </span>
     </div>
 

--- a/src/hi/apps/system/templates/system/panes/health_status_details.html
+++ b/src/hi/apps/system/templates/system/panes/health_status_details.html
@@ -11,7 +11,7 @@
     <div class="col-12">
       <div class="d-flex align-items-center mb-3">
         <span class="badge monitor-status-badge {{ health_status.status_badge_class }} mr-3">
-          {% icon health_status.status_icon size="sm" css_class="mr-2" %}
+          {% icon health_status.status_icon css_class="mr-2" %}
           {{ health_status.status_display }}
         </span>
       </div>
@@ -77,7 +77,7 @@
     <div class="col-12">
       <div class="alert {{ health_status.status_alert_class }}">
         <p class="mb-0">
-          {% icon health_status.status_icon size="sm" css_class="mr-2" %}
+          {% icon health_status.status_icon css_class="mr-2" %}
           {{ health_status.status_summary_message }}
         </p>
       </div>
@@ -89,7 +89,7 @@
   <div class="row">
     <div class="col-12">
       <h6 class="mb-3">
-        {% icon "plug" size="sm" css_class="mr-2" %}
+        {% icon "plug" css_class="mr-2" %}
         API Sources
       </h6>
 
@@ -106,7 +106,7 @@
   <div class="row mt-4">
     <div class="col-12">
       <h6 class="mb-3">
-        {% icon "tasks" size="sm" css_class="mr-2" %}
+        {% icon "tasks" css_class="mr-2" %}
         Components
       </h6>
 

--- a/src/hi/apps/system/templates/system/panes/integration_paused_card.html
+++ b/src/hi/apps/system/templates/system/panes/integration_paused_card.html
@@ -17,7 +17,7 @@
       <div class="d-flex justify-content-between align-items-center mb-2">
         <h6 class="mb-0">{{ integration_data.label }}</h6>
         <span class="badge monitor-status-badge badge-warning">
-          {% icon "pause" size="sm" css_class="mr-1" %}Paused
+          {% icon "pause" css_class="mr-1" %}Paused
         </span>
       </div>
       <div class="row">

--- a/src/hi/apps/system/templates/system/panes/subordinate_health_status_details.html
+++ b/src/hi/apps/system/templates/system/panes/subordinate_health_status_details.html
@@ -17,7 +17,7 @@ Parameters:
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h5 class="mb-0">{{ subordinate_health_status.provider_name }}</h5>
     <span class="badge {{ subordinate_health_status.status_badge_class }}">
-      {% icon subordinate_health_status.status_icon size="sm" css_class="mr-1" %}{{ subordinate_health_status.status.label }}
+      {% icon subordinate_health_status.status_icon css_class="mr-1" %}{{ subordinate_health_status.status.label }}
     </span>
   </div>
 

--- a/src/hi/apps/weather/templates/weather/panes/conditions.html
+++ b/src/hi/apps/weather/templates/weather/panes/conditions.html
@@ -79,7 +79,7 @@
      class="alert {{ weather_pane_status.caption_alert_class }} py-1 px-2 mb-0 d-flex align-items-center small"
      role="status"
      data-async="modal">
-    {% icon weather_pane_status.caption_icon size="sm" css_class="hi-icon-left" %}<span>{{ weather_pane_status.caption_text }}</span>
+    {% icon weather_pane_status.caption_icon css_class="hi-icon-left" %}<span>{{ weather_pane_status.caption_text }}</span>
   </a>
   {% if conditions.temperature.source %}
   <small class="text-muted d-block mt-1"><em>Last reading: {{ conditions.temperature.source_datetime |localtime|date:"g:i A" }} from {{ conditions.temperature.source.abbreviation }}</em></small>

--- a/src/hi/apps/weather/templates/weather/panes/weather_overview.html
+++ b/src/hi/apps/weather/templates/weather/panes/weather_overview.html
@@ -1,5 +1,5 @@
 {% load icons %}
-<div id="{{ DIVID.WEATHER_OVERVIEW }}">
+<div id="{{ DIVID.WEATHER_OVERVIEW }}" class="mx-2">
   <a class="clickable-card" href="{% url 'weather_current_conditions_details' %}" data-async="modal">
     {% include "weather/panes/conditions.html" with conditions=weather_overview_data.current_conditions_data weather_stats=weather_overview_data.todays_weather_stats %}
   </a>

--- a/src/hi/integrations/templates/integrations/connector/modals/integration_disable.html
+++ b/src/hi/integrations/templates/integrations/connector/modals/integration_disable.html
@@ -62,7 +62,7 @@
 {% if removal_summary.has_mixed_state %}
 <button type="submit" class="btn btn-outline-danger ml-2"
         name="mode" value="{{ disable_mode_all }}">
-  {% icon "warning" size="sm" css_class="hi-icon-left" %}DELETE ALL
+  {% icon "warning" css_class="hi-icon-left" %}DELETE ALL
 </button>
 {% endif %}
 {% endblock %}
@@ -71,12 +71,12 @@
 {% if removal_summary.has_mixed_state %}
 <button type="submit" class="btn btn-secondary"
         name="mode" value="{{ disable_mode_safe }}">
-  {% icon "shield" size="sm" css_class="hi-icon-left" %}DELETE SAFE
+  {% icon "shield" css_class="hi-icon-left" %}DELETE SAFE
 </button>
 {% else %}
 <button type="submit" class="btn btn-danger"
         name="mode" value="{{ disable_mode_safe }}">
-  {% icon "delete" size="sm" css_class="hi-icon-left" %}DELETE
+  {% icon "delete" css_class="hi-icon-left" %}DELETE
 </button>
 {% endif %}
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/connector/modals/integrations_select.html
+++ b/src/hi/integrations/templates/integrations/connector/modals/integrations_select.html
@@ -20,15 +20,15 @@ All Connectors
   <div class="col-3">
     {% if not integration_data.integration.is_enabled %}
     <span class="text-muted">
-      {% icon "disabled" size="sm" css_class="hi-icon-left" %}Not configured
+      {% icon "disabled" css_class="hi-icon-left" %}Not configured
     </span>
     {% elif integration_data.integration.is_paused %}
     <span class="font-weight-bold text-secondary">
-      {% icon "pause" size="sm" css_class="hi-icon-left" %}Paused
+      {% icon "pause" css_class="hi-icon-left" %}Paused
     </span>
     {% else %}
     <span class="font-weight-bold text-primary">
-      {% icon "check-circle" size="sm" css_class="hi-icon-left" %}Running
+      {% icon "check-circle" css_class="hi-icon-left" %}Running
     </span>
     {% endif %}
   </div>
@@ -37,12 +37,12 @@ All Connectors
     {% if integration_data.integration.is_enabled %}
     <a href="{% url 'integrations_connect_disable' integration_id=integration_data.integration.integration_id %}"
        role="button" class="btn btn-danger btn-control" data-async="modal">
-      {% icon "delete" size="sm" css_class="hi-icon-left" %}DISABLE
+      {% icon "delete" css_class="hi-icon-left" %}DISABLE
     </a>
     {% else %}
     <a href="{% url 'integrations_connect_configure' integration_id=integration_data.integration.integration_id %}"
        class="btn btn-primary btn-control" role="button" data-async="modal">
-      {% icon "settings" size="sm" css_class="hi-icon-left" %}CONFIGURE
+      {% icon "settings" css_class="hi-icon-left" %}CONFIGURE
     </a>
     {% endif %}
   </div>

--- a/src/hi/integrations/templates/integrations/connector/modals/pre_sync_confirm.html
+++ b/src/hi/integrations/templates/integrations/connector/modals/pre_sync_confirm.html
@@ -94,13 +94,13 @@ Check {{ integration_data.label }} for updates?
 <a class="btn btn-outline-primary"
    href="{% url 'integrations_connect_sync_preview' integration_id=integration_data.integration_id %}"
    role="button" data-async="modal">
-  {% icon "eye" size="sm" css_class="hi-icon-left" %}PREVIEW CHANGES
+  {% icon "eye" css_class="hi-icon-left" %}PREVIEW CHANGES
 </a>
 {% endif %}
 {% if removal_summary.has_mixed_state %}
 <button type="submit" class="btn btn-outline-danger ml-2"
         name="preserve_user_data" value="false">
-  {% icon "warning" size="sm" css_class="hi-icon-left" %}REMOVE MISSING
+  {% icon "warning" css_class="hi-icon-left" %}REMOVE MISSING
 </button>
 {% endif %}
 {% endblock %}
@@ -113,7 +113,7 @@ Check {{ integration_data.label }} for updates?
 {% elif removal_summary.has_mixed_state %}
 <button type="submit" class="btn btn-primary"
         name="preserve_user_data" value="true">
-  {% icon "shield" size="sm" css_class="hi-icon-left" %}RETAIN MISSING
+  {% icon "shield" css_class="hi-icon-left" %}RETAIN MISSING
 </button>
 {% else %}
 <button type="submit" class="btn btn-primary">

--- a/src/hi/integrations/templates/integrations/connector/modals/sync_preview_result.html
+++ b/src/hi/integrations/templates/integrations/connector/modals/sync_preview_result.html
@@ -86,7 +86,7 @@ Preview: {{ sync_result.title }}
 {% if sync_result.detached_list %}
 <button type="submit" class="btn btn-outline-danger"
         name="preserve_user_data" value="false">
-  {% icon "warning" size="sm" css_class="hi-icon-left" %}REMOVE MISSING
+  {% icon "warning" css_class="hi-icon-left" %}REMOVE MISSING
 </button>
 {% endif %}
 {% endblock %}
@@ -95,7 +95,7 @@ Preview: {{ sync_result.title }}
 {% if sync_result.detached_list %}
 <button type="submit" class="btn btn-primary"
         name="preserve_user_data" value="true">
-  {% icon "shield" size="sm" css_class="hi-icon-left" %}RETAIN MISSING
+  {% icon "shield" css_class="hi-icon-left" %}RETAIN MISSING
 </button>
 {% else %}
 <button type="submit" class="btn btn-primary"

--- a/src/hi/integrations/templates/integrations/connector/modals/sync_result.html
+++ b/src/hi/integrations/templates/integrations/connector/modals/sync_result.html
@@ -75,7 +75,7 @@
 <a id="hi-modal-cancel" role="button"
    class="btn btn-outline-tertiary"
    href="#"
-   onclick="location.reload(); return false;">{% icon "close" size="sm" css_class="hi-icon-left" %}Place Later</a>
+   onclick="location.reload(); return false;">{% icon "close" css_class="hi-icon-left" %}Place Later</a>
 {% endif %}
 {% endblock %}
 
@@ -91,6 +91,6 @@
 {% block action_right %}
 {% if sync_result.created_list and placement_url %}
 <a class="btn btn-primary" role="button"
-   href="{{ placement_url }}" data-async="modal">Place new items {% icon "chevron-right" size="sm" css_class="hi-icon-right" %}</a>
+   href="{{ placement_url }}" data-async="modal">Place new items {% icon "chevron-right" css_class="hi-icon-right" %}</a>
 {% endif %}
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/connector/pages/integration_manage.html
+++ b/src/hi/integrations/templates/integrations/connector/pages/integration_manage.html
@@ -8,7 +8,7 @@
       <a class="btn btn-outline-primary w-100" role="button"
          href="{% url 'integrations_connect_select' %}"
          data-async="modal">
-        {% icon "settings" size="sm" css_class="hi-icon-left" %}CONNECTORS
+        {% icon "settings" css_class="hi-icon-left" %}CONNECTORS
       </a>
     </div>
     {% for item in core.sidebar_items %}
@@ -62,7 +62,7 @@
           </div>
           {% if core.sync_check_result and core.sync_check_result.needs_sync %}
           <div class="alert alert-info py-2 mt-2 mb-0" role="status">
-            {% icon "sync" size="sm" css_class="hi-icon-left" %}{{ core.sync_check_result.summary_message }}
+            {% icon "sync" css_class="hi-icon-left" %}{{ core.sync_check_result.summary_message }}
             Click
             <a href="{% url 'integrations_connect_pre_sync' integration_id=core.integration_data.integration_id %}"
                class="alert-link"

--- a/src/hi/integrations/templates/integrations/connector/panes/integration_health_banner.html
+++ b/src/hi/integrations/templates/integrations/connector/panes/integration_health_banner.html
@@ -20,7 +20,7 @@ of the health-status UI.
 {% if health_status and not health_status.is_healthy %}
 <div class="alert {{ health_status.status_alert_class }} d-flex align-items-start mb-3 py-2"
      role="alert">
-  {% icon health_status.status_icon size="sm" css_class="mr-2 mt-1" %}
+  {% icon health_status.status_icon css_class="mr-2 mt-1" %}
   <div>
     <strong>{{ integration_label }}: {{ health_status.status_display }}</strong>
     {% if context_message %}

--- a/src/hi/integrations/templates/integrations/connector/panes/integration_status_indicator.html
+++ b/src/hi/integrations/templates/integrations/connector/panes/integration_status_indicator.html
@@ -34,20 +34,20 @@ UNKNOWN is intentionally not handled -- initialization edge, transient.
         role="img"
         aria-label="{{ health_status.status.label }}{% if health_status.last_message %}: {{ health_status.last_message }}{% endif %}"
         title="{{ health_status.status.label }}{% if health_status.last_message %}: {{ health_status.last_message }}{% endif %}">
-    {% icon "warning" size="sm" %}
+    {% icon "warning" %}
   </span>
 {% elif is_paused %}
   <span class="hi-integration-indicator hi-integration-indicator-paused"
         role="img"
         aria-label="Paused — background monitor is suspended"
         title="Paused — background monitor is suspended">
-    {% icon "pause" size="sm" %}
+    {% icon "pause" %}
   </span>
 {% elif sync_check_result.needs_sync %}
   <span class="hi-integration-indicator hi-integration-indicator-needs-sync"
         role="img"
         aria-label="{{ sync_check_result.summary_message }}"
         title="{{ sync_check_result.summary_message }}">
-    {% icon "sync" size="sm" %}
+    {% icon "sync" %}
   </span>
 {% endif %}

--- a/src/hi/integrations/templates/integrations/importer/modals/import_discard_confirm.html
+++ b/src/hi/integrations/templates/integrations/importer/modals/import_discard_confirm.html
@@ -38,7 +38,7 @@
 {% block action_right %}
 {% if imported_count > 0 %}
 <button type="submit" class="btn btn-danger">
-  {% icon "delete" size="sm" css_class="hi-icon-left" %}DISCARD
+  {% icon "delete" css_class="hi-icon-left" %}DISCARD
 </button>
 {% endif %}
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/importer/modals/import_result.html
+++ b/src/hi/integrations/templates/integrations/importer/modals/import_result.html
@@ -91,7 +91,7 @@
 <a id="hi-modal-cancel" role="button"
    class="btn btn-outline-tertiary"
    href="#"
-   onclick="location.reload(); return false;">{% icon "close" size="sm" css_class="hi-icon-left" %}Place Later</a>
+   onclick="location.reload(); return false;">{% icon "close" css_class="hi-icon-left" %}Place Later</a>
 {% endif %}
 {% endblock %}
 
@@ -107,6 +107,6 @@
 {% block action_right %}
 {% if result.has_imports and placement_url %}
 <a class="btn btn-primary" role="button"
-   href="{{ placement_url }}" data-async="modal">Place new items {% icon "chevron-right" size="sm" css_class="hi-icon-right" %}</a>
+   href="{{ placement_url }}" data-async="modal">Place new items {% icon "chevron-right" css_class="hi-icon-right" %}</a>
 {% endif %}
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/importer/pages/data_import_page.html
+++ b/src/hi/integrations/templates/integrations/importer/pages/data_import_page.html
@@ -21,18 +21,18 @@
              title="What's the difference?"
              class="d-block text-muted small text-decoration-none mb-3">
             Also available as a Connector.
-            {% icon "info-circle" size="sm" %}
+            {% icon "info-circle" %}
           </a>
           {% endif %}
           <div class="mt-auto pt-2">
             <a href="{% url 'integrations_import_configure' integration_id=row.integration_data.integration_id %}"
                class="btn btn-primary btn-block" role="button" data-async="modal">
-              {% icon "settings" size="sm" css_class="hi-icon-left" %}CONFIGURE
+              {% icon "settings" css_class="hi-icon-left" %}CONFIGURE
             </a>
             {% if row.has_imported %}
             <a href="{% url 'integrations_import_discard' integration_id=row.integration_data.integration_id %}"
                role="button" class="btn btn-outline-danger btn-block mt-2" data-async="modal">
-              {% icon "delete" size="sm" css_class="hi-icon-left" %}DISCARD
+              {% icon "delete" css_class="hi-icon-left" %}DISCARD
             </a>
             {% endif %}
           </div>

--- a/src/hi/integrations/templates/integrations/modals/capability_blocked.html
+++ b/src/hi/integrations/templates/integrations/modals/capability_blocked.html
@@ -22,6 +22,6 @@
 {% block action_right %}
 <a class="btn btn-primary" role="button"
    href="{{ link_url }}" data-async="page">
-  {% icon "chevron-right" size="sm" css_class="hi-icon-left" %}{{ link_label }}
+  {% icon "chevron-right" css_class="hi-icon-left" %}{{ link_label }}
 </a>
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/modals/external_reference_attach_errors.html
+++ b/src/hi/integrations/templates/integrations/modals/external_reference_attach_errors.html
@@ -50,7 +50,7 @@ Context:
    class="btn btn-outline-primary"
    href="{{ picker_url }}"
    data-async="modal">
-  {% icon "link" size="sm" css_class="hi-icon-left" %}LINK MORE
+  {% icon "link" css_class="hi-icon-left" %}LINK MORE
 </a>
 {% endblock %}
 
@@ -59,6 +59,6 @@ Context:
    class="btn btn-outline-tertiary"
    href="{{ owner_edit_url }}"
    data-async="modal">
-  {% icon "close" size="sm" css_class="hi-icon-left" %}DISMISS
+  {% icon "close" css_class="hi-icon-left" %}DISMISS
 </a>
 {% endblock %}

--- a/src/hi/integrations/templates/integrations/modals/placement.html
+++ b/src/hi/integrations/templates/integrations/modals/placement.html
@@ -206,7 +206,7 @@ Place new items
 
 {% block action_right %}
 <button type="submit" name="action" value="apply" class="btn btn-primary">
-  {% icon "check-circle" size="sm" css_class="hi-icon-left" %}APPLY
+  {% icon "check-circle" css_class="hi-icon-left" %}APPLY
 </button>
 {% endblock %}
 

--- a/src/hi/integrations/templates/integrations/modals/placement_dismiss.html
+++ b/src/hi/integrations/templates/integrations/modals/placement_dismiss.html
@@ -39,7 +39,7 @@ Items left unplaced
 {% block action_left %}
 <a class="btn btn-outline-tertiary" role="button"
    href="{{ placement_url }}" data-async="modal">
-  {% icon "chevron-left" size="sm" css_class="hi-icon-left" %}GO BACK
+  {% icon "chevron-left" css_class="hi-icon-left" %}GO BACK
 </a>
 {% endblock %}
 

--- a/src/hi/integrations/templates/integrations/modals/post_placement.html
+++ b/src/hi/integrations/templates/integrations/modals/post_placement.html
@@ -116,9 +116,9 @@ Update check complete
 {% if primary_action %}
 <a class="btn btn-primary" href="{{ primary_action.1 }}">
   {% if primary_action.0.is_view %}
-  {% icon "edit" size="sm" css_class="hi-icon-left" %}REFINE
+  {% icon "edit" css_class="hi-icon-left" %}REFINE
   {% else %}
-  {% icon "view" size="sm" css_class="hi-icon-left" %}REVIEW
+  {% icon "view" css_class="hi-icon-left" %}REVIEW
   {% endif %}
   {{ primary_action.0.target_name }}
 </a>

--- a/src/hi/integrations/templates/integrations/panes/integration_edit_content_body.html
+++ b/src/hi/integrations/templates/integrations/panes/integration_edit_content_body.html
@@ -8,7 +8,7 @@
 {% if show_modal_cancel %}
 <a id="hi-modal-cancel" role="button" {% if autofocus %}autofocus="autofocus"{% endif %}
    class="btn btn-outline-tertiary" href="#" data-dismiss="modal">
-  {% icon "cancel" size="sm" css_class="hi-icon-left" %}CANCEL
+  {% icon "cancel" css_class="hi-icon-left" %}CANCEL
 </a>
 {% endif %}
 

--- a/src/hi/integrations/templates/integrations/referencer/modals/external_reference_picker.html
+++ b/src/hi/integrations/templates/integrations/referencer/modals/external_reference_picker.html
@@ -67,7 +67,7 @@ Link Content
        class="btn btn-outline-tertiary"
        href="{{ owner_edit_url }}"
        data-async="modal">
-      {% icon "cancel" size="sm" css_class="hi-icon-left" %}CANCEL
+      {% icon "cancel" css_class="hi-icon-left" %}CANCEL
     </a>
     {% comment %}
     No ``data-async`` here: external-reference-picker.js owns the submit so it can
@@ -91,7 +91,7 @@ Link Content
       <button type="submit"
               class="btn btn-primary {{ DIVID.REF_PICKER_ATTACH_BTN_CLASS }}"
               disabled>
-        {% icon "check-circle" size="sm" css_class="hi-icon-left" %}<span class="{{ DIVID.REF_PICKER_ATTACH_LABEL_CLASS }}">Add 0 Links</span>
+        {% icon "check-circle" css_class="hi-icon-left" %}<span class="{{ DIVID.REF_PICKER_ATTACH_LABEL_CLASS }}">Add 0 Links</span>
       </button>
     </form>
   </div>

--- a/src/hi/integrations/templates/integrations/referencer/pages/integration_manage.html
+++ b/src/hi/integrations/templates/integrations/referencer/pages/integration_manage.html
@@ -7,7 +7,7 @@
     <div class="hi-vertical-nav-header">
       <span class="d-flex align-items-center justify-content-center w-100 font-weight-bold text-muted py-2"
             style="white-space: nowrap;">
-        {% icon "collection" size="sm" css_class="hi-icon-left" %}CONTENT SOURCES
+        {% icon "collection" css_class="hi-icon-left" %}CONTENT SOURCES
       </span>
     </div>
     {% for item in core.integration_data_list %}

--- a/src/hi/integrations/templates/integrations/referencer/panes/attribute_actions.html
+++ b/src/hi/integrations/templates/integrations/referencer/panes/attribute_actions.html
@@ -11,7 +11,7 @@ Context (inherited from the surrounding edit body):
 {% endcomment %}
 {% if integration_data.integration.is_enabled %}
 <span class="badge badge-success ml-3 px-2 py-1 align-self-center">
-  {% icon "check-circle" size="sm" css_class="hi-icon-left" %}ENABLED
+  {% icon "check-circle" css_class="hi-icon-left" %}ENABLED
 </span>
 {% comment %}
 DISABLE shares the surrounding attribute form (HTML forbids nested
@@ -24,10 +24,10 @@ ignores ``formaction``). Dispatch is via the ``action`` POST field
         value="disable"
         formnovalidate
         class="btn btn-outline-danger ml-2">
-  {% icon "close" size="sm" css_class="hi-icon-left" %}DISABLE
+  {% icon "close" css_class="hi-icon-left" %}DISABLE
 </button>
 {% else %}
 <span class="badge badge-secondary ml-3 px-2 py-1 align-self-center">
-  {% icon "info-circle" size="sm" css_class="hi-icon-left" %}DISABLED
+  {% icon "info-circle" css_class="hi-icon-left" %}DISABLED
 </span>
 {% endif %}

--- a/src/hi/integrations/templates/integrations/referencer/panes/external_reference_picker_results.html
+++ b/src/hi/integrations/templates/integrations/referencer/panes/external_reference_picker_results.html
@@ -50,7 +50,7 @@ Context:
     {% else %}
     <div class="mr-3 d-flex align-items-center justify-content-center bg-light rounded text-muted"
          style="width: 56px; height: 56px;">
-      {% icon "info-circle" size="sm" %}
+      {% icon "info-circle" %}
     </div>
     {% endif %}
     <div class="flex-grow-1" style="min-width: 0;">

--- a/src/hi/templates/modals/action_cancel.html
+++ b/src/hi/templates/modals/action_cancel.html
@@ -4,6 +4,6 @@
 {% block action_center %}
 <a id="hi-modal-cancel" role="button" {% if autofocus %}autofocus="autofocus"{% endif %}
    class="btn btn-outline-tertiary" href="#" data-dismiss="modal">
-  {% icon "cancel" size="sm" css_class="hi-icon-left" %}CANCEL
+  {% icon "cancel" css_class="hi-icon-left" %}CANCEL
 </a>
 {% endblock %}

--- a/src/hi/templates/modals/action_with_cancel.html
+++ b/src/hi/templates/modals/action_with_cancel.html
@@ -4,6 +4,6 @@
 {% block action_left %}
 <a id="hi-modal-cancel" role="button" {% if autofocus %}autofocus="autofocus"{% endif %}
    class="btn btn-outline-tertiary" href="#" data-dismiss="modal">
-  {% icon "cancel" size="sm" css_class="hi-icon-left" %}CANCEL
+  {% icon "cancel" css_class="hi-icon-left" %}CANCEL
 </a>
 {% endblock %}

--- a/src/hi/templates/modals/base.html
+++ b/src/hi/templates/modals/base.html
@@ -22,7 +22,7 @@
           <button id="modal_dismiss_x"
                   type="button" class=" w-100 text-center text-white close"
                   data-dismiss="modal" aria-label="Close modal">
-            {% icon "close" size="sm" %}
+            {% icon "close" %}
           </button>
           {% endblock %}
         </div>

--- a/src/hi/templates/panes/bottom_buttons.html
+++ b/src/hi/templates/panes/bottom_buttons.html
@@ -6,7 +6,7 @@
       <a href="{% url 'collection_add' %}"
          class="btn btn-add btn-control" role="button"
          data-async="modal" >
-        {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD COLLECTION
+        {% icon "plus" css_class="hi-icon-left" %}ADD COLLECTION
       </a>
     </div>
     {% endif %}
@@ -24,7 +24,7 @@
         <a href="{% url 'profiles_edit_reference_help' %}"
            class="btn btn-tertiary btn-control" role="button"
            data-async="true" >
-          {% icon "question-circle" size="sm" css_class="hi-icon-left" %}EDIT HELP
+          {% icon "question-circle" css_class="hi-icon-left" %}EDIT HELP
         </a>
       </div>
       {% else %}
@@ -41,7 +41,7 @@
         <a href="{% url 'config_home' %}"
            class="btn btn-tertiary btn-control" role="button"
            data-async="true" >
-          {% icon "settings" size="sm" css_class="hi-icon-left" %}CONFIGURE
+          {% icon "settings" css_class="hi-icon-left" %}CONFIGURE
         </a>
       </div>
       {% endif %}

--- a/src/hi/templates/panes/top_buttons.html
+++ b/src/hi/templates/panes/top_buttons.html
@@ -7,7 +7,7 @@
       <a href="{% url 'location_edit_location_view_add' %}"
          class="btn btn-add btn-control" role="button"
          data-async="modal" >
-        {% icon "plus" size="sm" css_class="hi-icon-left" %}ADD VIEW
+        {% icon "plus" css_class="hi-icon-left" %}ADD VIEW
       </a>
     </div>
     {% endif %}
@@ -22,14 +22,14 @@
         <a class="btn btn-primary btn-control" role="button"
            href="{% url 'location_edit_mode' location_id=request.view_parameters.location.id %}"
            data-async="true" >
-          {% icon "edit" size="sm" css_class="" %}
+          {% icon "edit" css_class="" %}
           {{ request.view_parameters.location.name|truncatechars:18 }}
         </a>
         {% else %}
         <a class="btn btn-primary btn-control" role="button"
            href="{% url 'location_edit_location_edit' location_id=request.view_parameters.location.id %}"
              data-async="true" >
-          {% icon "info-circle" size="sm" css_class="hi-icon-left" %}{{ request.view_parameters.location.name|truncatechars:18 }}
+          {% icon "info-circle" css_class="hi-icon-left" %}{{ request.view_parameters.location.name|truncatechars:18 }}
         </a>
         {% endif %}
       </div>
@@ -41,12 +41,12 @@
         {% if request.view_parameters.is_editing %}
         <a href="{% url 'edit_end' %}"
            class="btn btn-tertiary btn-control" role="button" >
-          {% icon "close" size="sm" css_class="hi-icon-left" %}EXIT EDIT
+          {% icon "close" css_class="hi-icon-left" %}EXIT EDIT
         </a>
         {% else %}
         <a href="{% url 'edit_start' %}"
            class="btn btn-tertiary btn-control" role="button" >
-          {% icon "edit" size="sm" css_class="hi-icon-left" %}EDIT
+          {% icon "edit" css_class="hi-icon-left" %}EDIT
         </a>
         {% endif %}
       </div>


### PR DESCRIPTION
## Pull Request: Normalize icon sizes — drop misplaced `size="sm"` for visual parity with adjacent text

### Issue Link

(No tracking issue — observation-driven cleanup raised in chat.)

---

## Category

- [ ] **Feature** (New functionality)
- [ ] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)
- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code improvements without changing functionality)
- [x] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

Across the app, `{% icon %}` was overwhelmingly invoked with `size="sm"` even inside full-size buttons. At 0.875rem (14px) the icon reads as smaller than the adjacent ~16px button label, so chrome looks subtly under-weighted everywhere. This pass drops `size="sm"` from contexts where it shouldn't have been there — the icon tag's default is `md` (1rem), which matches the surrounding text.

- **141 `size="sm"` removed** across **83 templates**. Affected: modal action buttons (UPDATE / EDIT / DELETE / CANCEL / etc.), top/bottom nav buttons, sticky-panel chrome, tab nav-links, system health/status pane badges, integration manage / configure / placement chrome.
- **109 `size="sm"` kept** where it was the right call:
  - Inside `.btn-sm` buttons (icon matches Bootstrap's small-button text size).
  - Pagination chevrons (compact nav widget).
  - Alert-banner decorative chevron triple (intentional small ornament).
  - Inline icons embedded in body prose (`audio_permission_guidance.html`).
  - Demo / test pages (`icon_browser.html`, `system/tests/ui/home.html`, `view_reference_help.html`, `edit_reference_help.html`).
  - All `hi/simulator/` templates (operator tooling, left alone for consistency).

**Classification rule applied:** for every `size="sm"` occurrence in a non-excluded file, the five lines preceding the icon were inspected for `.btn-sm`. If present, the icon was kept at `sm`; otherwise `size="sm"` was removed so the default `md` takes over.

Two unrelated margin tweaks are included on this branch by request:
- `console/panes/hi_grid_side.html`: `my-2` → `m-2` on the event-history button wrapper.
- `weather/panes/weather_overview.html`: added `mx-2` on the overview container.

---

## How to Test

1. Open any entity / location edit modal and inspect the action-row buttons (UPDATE, EDIT, STATUS, DELETE, ADD). Icons should now read as roughly the same height as the button label rather than visibly smaller.
2. Top buttons (`ADD VIEW`, edit-mode toggle, `EXIT EDIT`) and bottom buttons (`ADD COLLECTION`, `EDIT HELP`) — same check.
3. Tab nav-links on the entity/location edit modal — `Linked Content` icon should match the `Home Information` logo (both ~16px) rather than being noticeably smaller.
4. System pane health/status badges — icon + status label should feel balanced.
5. Confirm the **unchanged** chrome still looks right at `sm`:
   - Pagination chevrons.
   - Alert banner's chevron triple.
   - The lock / shield icons embedded inside `<li>` prose in the audio permission modal.
   - Small action-row buttons inside `.btn-sm` (e.g., the per-card history / sync / chevron buttons on regular and file attribute cards).
6. `make test` — 3513 pass.
7. `make lint` — clean.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary. _(Template-only change; no test impact.)_
- [x] All tests pass (`./manage.py test`).
- [x] Docs updated if applicable. _(N/A — no public-facing docs reference icon size choices.)_
- [x] No breaking changes introduced.

---

## Related PRs

#392 (External Reference framework) — that PR introduced several of the icons this sweep readjusts (sticky-panel `Add Info` / `Add File` / `Link Content`, the Linked Content tab nav, the ext-ref attach errors modal).

---

## Screenshots (if applicable)

_(Visual change; reviewer can compare modal chrome before/after via manual check above.)_

---

## Additional Notes

The icon template tag's existing default (`md`) is correct — this sweep just removes redundant overrides that were defaulting too small. Long term it might be worth a brief note in `icons.py` reminding contributors that `sm` should be opt-in for compact contexts only, not a generic default.

---

### **Ready for Review?**

- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
