### PR TITLE
Fix SecurityManager SynchronousOnlyOperation on async startup (#404)

### DIFF
--- a/src/hi/apps/alert/alert_manager.py
+++ b/src/hi/apps/alert/alert_manager.py
@@ -95,9 +95,13 @@ class AlertManager( Singleton, NotificationMixin, SecurityMixin ):
         notification_manager = await self.notification_manager_async()
         if not notification_manager:
             return
+        security_manager = await self.security_manager_async()
+        if not security_manager:
+            return
         self._upsert_alarm_impl(
             alarm = alarm,
             notification_manager = notification_manager,
+            security_state = security_manager.security_state,
         )
         return
 
@@ -115,12 +119,12 @@ class AlertManager( Singleton, NotificationMixin, SecurityMixin ):
         self._upsert_alarm_impl(
             alarm = alarm,
             notification_manager = notification_manager,
+            security_state = self.security_manager().security_state,
         )
         return
 
-    def _upsert_alarm_impl( self, alarm : Alarm, notification_manager ):
+    def _upsert_alarm_impl( self, alarm : Alarm, notification_manager, security_state ):
         logging.debug( f'Adding Alarm: {alarm}' )
-        security_state = self.security_manager().security_state
         try:
             alert = self._alert_queue.add_alarm( alarm = alarm )
             if security_state.uses_notifications and alert.has_single_alarm:
@@ -150,7 +154,7 @@ class AlertManager( Singleton, NotificationMixin, SecurityMixin ):
             result.alerts_after_cleanup = len(self._alert_queue)
 
         except Exception as e:
-            logger.exception( 'Problem doing periodic alert maintenance.', e )
+            logger.exception( 'Problem doing periodic alert maintenance.' )
             result.error_message = str(e)[:100]  # Truncate long error messages
 
         return result

--- a/src/hi/apps/alert/tests/test_alert_manager.py
+++ b/src/hi/apps/alert/tests/test_alert_manager.py
@@ -1,12 +1,13 @@
 import logging
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import hi.apps.common.datetimeproxy as datetimeproxy
 from hi.apps.alert.alert_manager import AlertManager, AlertMaintenanceResult
 from hi.apps.alert.alarm import Alarm, AlarmSignature
 from hi.apps.alert.enums import AlarmLevel, AlarmSource
+from hi.apps.alert.tests.synthetic_data import AlertSyntheticData
 from hi.apps.security.enums import SecurityLevel
-from hi.testing.async_task_utils import AsyncTaskFastTestCase
+from hi.testing.async_task_utils import AsyncTaskFastTestCase, AsyncTaskTestCase
 from hi.testing.base_test_case import BaseTestCase
 
 logging.disable(logging.CRITICAL)
@@ -413,6 +414,41 @@ class TestAlertManagerMaintenance(AsyncTaskFastTestCase):
                 self.assertIsInstance(result, AlertMaintenanceResult)
                 self.assertEqual(result.alerts_before_cleanup, 0)  # Empty queue before exception
                 self.assertIn("Test exception", result.error_message)
+
+        self.run_async(async_test_logic())
+
+
+class TestAlertManagerAsyncSecurityInit(AsyncTaskTestCase):
+    """Regression for issue #404: the async alarm path (reached e.g. from
+    WeatherManager) must obtain SecurityManager via the async accessor. The
+    synchronous accessor runs a sync ORM query on the loop, which
+    SecurityManager.ensure_initialized() swallows while forcing security state
+    DISABLED -- a silent fault. We assert the accessor contract directly."""
+
+    def setUp(self):
+        super().setUp()
+        AlertManager._instance = None
+        self.manager = AlertManager()
+
+    def test_upsert_alarm_async_uses_async_security_accessor(self):
+        async def async_test_logic():
+            alarm = AlertSyntheticData.create_single_alarm_alert().first_alarm
+
+            security_state = MagicMock()
+            security_state.uses_notifications = False  # skip the notify branch
+            security_manager = MagicMock()
+            security_manager.security_state = security_state
+
+            with patch.object( self.manager, 'notification_manager_async',
+                               new = AsyncMock( return_value = MagicMock() )), \
+                 patch.object( self.manager, 'security_manager_async',
+                               new = AsyncMock( return_value = security_manager )) as mock_async, \
+                 patch.object( self.manager, 'security_manager' ) as mock_sync:
+
+                await self.manager.upsert_alarm_async( alarm )
+
+            mock_async.assert_awaited_once()
+            mock_sync.assert_not_called()
 
         self.run_async(async_test_logic())
 

--- a/src/hi/apps/attribute/tests/test_models.py
+++ b/src/hi/apps/attribute/tests/test_models.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import shutil
 import uuid
 from unittest.mock import patch, call
 
@@ -266,7 +267,31 @@ class TestAttributeModel(BaseTestCase):
 
             generated = AttributeThumbnail(attr).generate_thumbnail_best_effort()
 
-            self.assertTrue(generated)
+            # The app degrades gracefully when poppler is absent (returns
+            # False), but this integration test asserts the feature actually
+            # works -- poppler-utils is a required dependency in Docker and CI.
+            # Make the failure self-explanatory when run without it locally.
+            poppler_binary = shutil.which('pdftoppm') or shutil.which('pdftocairo')
+            if poppler_binary:
+                failure_reason = (
+                    f'poppler was found at {poppler_binary!r}, so PDF rendering '
+                    'failed for another reason -- check the logged '
+                    '"Error rendering PDF thumbnail" warning above.'
+                )
+            else:
+                failure_reason = (
+                    'the poppler system binary (pdftoppm/pdftocairo) is not on '
+                    'PATH. pdf2image shells out to poppler-utils, a required '
+                    'dependency (installed automatically in Docker and CI). '
+                    'Install it locally -- macOS: "brew install poppler"; '
+                    'Debian/Ubuntu: "sudo apt install poppler-utils". '
+                    'See docs/dev/Dependencies.md.'
+                )
+
+            self.assertTrue(
+                generated,
+                msg=f'PDF thumbnail generation returned False because {failure_reason}',
+            )
             self.assertTrue(default_storage.exists(attr.thumbnail_relative_path))
             self.assertTrue(attr.has_thumbnail)
             self.assertIsNotNone(attr.thumbnail_url)

--- a/src/hi/apps/common/email_utils.py
+++ b/src/hi/apps/common/email_utils.py
@@ -100,6 +100,6 @@ class EmailThread( threading.Thread ):
     def run(self):
         try:
             self.message.send()
-        except Exception as e:
-            logger.exception( 'Problem in email thread.', e )
+        except Exception:
+            logger.exception( 'Problem in email thread.' )
         return

--- a/src/hi/apps/config/settings_manager.py
+++ b/src/hi/apps/config/settings_manager.py
@@ -78,8 +78,8 @@ class SettingsManager( Singleton ):
         for callback in self._change_listeners:
             try:
                 callback()
-            except Exception as e:
-                logger.exception( 'Problem calling setting change callback.', e )
+            except Exception:
+                logger.exception( 'Problem calling setting change callback.' )
             continue
         return
 

--- a/src/hi/apps/config/signals.py
+++ b/src/hi/apps/config/signals.py
@@ -38,8 +38,8 @@ class SettingsInitializer:
                 if len(app_settings) > 0:
                     app_settings_list.append( app_settings )
                 
-            except Exception as e:
-                logger.exception( f'Problem loading settings for {module_name}.', e )
+            except Exception:
+                logger.exception( f'Problem loading settings for {module_name}.' )
             continue
 
         return app_settings_list

--- a/src/hi/apps/entity/entity_manager.py
+++ b/src/hi/apps/entity/entity_manager.py
@@ -58,8 +58,8 @@ class EntityManager(Singleton):
         for callback in self._change_listeners:
             try:
                 callback()
-            except Exception as e:
-                logger.exception( 'Problem calling EntityManager change callback.', e )
+            except Exception:
+                logger.exception( 'Problem calling EntityManager change callback.' )
             continue
         return
 

--- a/src/hi/apps/event/event_manager.py
+++ b/src/hi/apps/event/event_manager.py
@@ -225,8 +225,11 @@ class EventManager( Singleton, AlertMixin, ControllerMixin, SecurityMixin ):
         if not alert_manager:
             return
         controller_manager = await self.controller_manager_async()
-        
-        current_security_level = self.security_manager().security_level
+
+        security_manager = await self.security_manager_async()
+        if not security_manager:
+            return
+        current_security_level = security_manager.security_level
 
         for event in event_list:
 
@@ -238,7 +241,9 @@ class EventManager( Singleton, AlertMixin, ControllerMixin, SecurityMixin ):
                 await alert_manager.upsert_alarm_async( alarm )
                 continue
             
-            control_actions = await sync_to_async(list)(event.event_definition.control_actions.all())
+            control_actions = await sync_to_async(list)(
+                event.event_definition.control_actions.select_related('controller').all()
+            )
             for control_action in control_actions:
                 await controller_manager.do_control_async(
                     controller = control_action.controller,

--- a/src/hi/apps/event/tests/test_event_manager.py
+++ b/src/hi/apps/event/tests/test_event_manager.py
@@ -1,11 +1,12 @@
 import logging
 from datetime import timedelta
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 from asgiref.sync import sync_to_async
 
 from django.utils import timezone
 
 from hi.apps.alert.enums import AlarmLevel
+from hi.apps.control.models import Controller
 from hi.apps.entity.models import Entity, EntityState
 from hi.apps.security.enums import SecurityLevel
 from hi.apps.sense.transient_models import SensorResponse
@@ -15,7 +16,7 @@ from hi.testing.async_task_utils import AsyncTaskTestCase
 
 from hi.apps.event.enums import EventClauseOperator, EventType
 from hi.apps.event.event_manager import EventManager
-from hi.apps.event.models import EventDefinition, EventClause, AlarmAction, EventHistory
+from hi.apps.event.models import EventDefinition, EventClause, AlarmAction, ControlAction, EventHistory
 from hi.apps.event.transient_models import EntityStateTransition, Event
 
 logging.disable(logging.CRITICAL)
@@ -215,6 +216,36 @@ class TestEventManagerTransitionProcessing(AsyncEventManagerTestCase):
                 # Verify event was created and cached
                 self.assertIn(event_def.id, manager._recent_events)
         
+        self.run_async(async_test_logic())
+        return
+
+    def test_do_new_event_action_uses_async_security_accessor(self):
+        """Regression for issue #404: _do_new_event_action runs on the event
+        loop, so it must obtain SecurityManager via the async accessor (which
+        wraps init in sync_to_async). The synchronous accessor runs a sync ORM
+        query on the loop -- SecurityManager.ensure_initialized() swallows the
+        resulting SynchronousOnlyOperation and forces security state DISABLED,
+        so the defect is silent; we assert the accessor contract directly."""
+        async def async_test_logic():
+            manager = EventManager()
+            security_manager = AsyncMock()
+            security_manager.security_level = SecurityLevel.OFF
+
+            # Sibling accessors truthy so we reach the security accessor; an
+            # empty event list skips the (separately tested) alarm loop.
+            with patch.object( manager, 'alert_manager_async',
+                               new = AsyncMock( return_value = AsyncMock() )), \
+                 patch.object( manager, 'controller_manager_async',
+                               new = AsyncMock( return_value = AsyncMock() )), \
+                 patch.object( manager, 'security_manager_async',
+                               new = AsyncMock( return_value = security_manager )) as mock_async, \
+                 patch.object( manager, 'security_manager' ) as mock_sync:
+
+                await manager._do_new_event_action( event_list = [] )
+
+            mock_async.assert_awaited_once()
+            mock_sync.assert_not_called()
+
         self.run_async(async_test_logic())
         return
 
@@ -523,13 +554,14 @@ class TestEventManagerEventActions(AsyncEventManagerTestCase):
             mock_alert_manager = AsyncMock()
             mock_controller_manager = AsyncMock()
             
+            # Security level HIGH (via the async accessor) matches the alarm action
+            mock_security_manager = MagicMock()
+            mock_security_manager.security_level = SecurityLevel.HIGH
+
             with patch.object(self.manager, 'alert_manager_async', return_value=mock_alert_manager), \
                  patch.object(self.manager, 'controller_manager_async', return_value=mock_controller_manager), \
-                 patch.object(self.manager, 'security_manager') as mock_security:
-                
-                # Set current security level to HIGH to match alarm action
-                mock_security.return_value.security_level = SecurityLevel.HIGH
-                
+                 patch.object(self.manager, 'security_manager_async', return_value=mock_security_manager):
+
                 # Call method under test - let it use real database operations
                 await self.manager._do_new_event_action([event])
                 
@@ -538,7 +570,53 @@ class TestEventManagerEventActions(AsyncEventManagerTestCase):
                 alarm_call_args = mock_alert_manager.upsert_alarm_async.call_args[0][0]
                 self.assertEqual(alarm_call_args.title, 'Test Event')
                 self.assertEqual(alarm_call_args.alarm_level, AlarmLevel.CRITICAL)
-        
+
+        self.run_async(async_test_logic())
+        return
+
+    def test_do_new_event_action_eager_loads_controller_for_control_actions(self):
+        """Regression for issue #404 (same class of bug): _do_new_event_action
+        runs on the event loop, so the ControlAction.controller FK must be
+        eager-loaded. Without select_related('controller'), reading
+        control_action.controller triggers a synchronous ORM query on the loop
+        -- a SynchronousOnlyOperation that (unlike the security path) is not
+        swallowed and would propagate out of the event action."""
+        async def async_test_logic():
+            entity, entity_state = await self.create_test_entities_async()
+            event_def = await self.create_test_event_definition_async()
+
+            controller = await sync_to_async(Controller.objects.create)(
+                name='Test Controller',
+                entity_state=entity_state,
+                controller_type_str='DEFAULT',
+                integration_id='ctrl_id',
+                integration_name='ctrl_integration',
+            )
+            await sync_to_async(ControlAction.objects.create)(
+                event_definition=event_def,
+                controller=controller,
+                value='on',
+            )
+
+            sensor_response = create_test_sensor_response(value='on', timestamp=timezone.now())
+            event = Event(event_definition=event_def, sensor_response_list=[sensor_response])
+
+            mock_controller_manager = AsyncMock()
+            mock_security_manager = MagicMock()
+            mock_security_manager.security_level = SecurityLevel.HIGH
+
+            with patch.object(self.manager, 'alert_manager_async', return_value=AsyncMock()), \
+                 patch.object(self.manager, 'controller_manager_async', return_value=mock_controller_manager), \
+                 patch.object(self.manager, 'security_manager_async', return_value=mock_security_manager):
+
+                # Reading control_action.controller below must not issue a sync
+                # ORM query on the loop -- select_related makes it loop-safe.
+                await self.manager._do_new_event_action([event])
+
+            mock_controller_manager.do_control_async.assert_awaited_once()
+            _, kwargs = mock_controller_manager.do_control_async.call_args
+            self.assertEqual(kwargs['controller'], controller)
+
         self.run_async(async_test_logic())
         return
 

--- a/src/hi/apps/monitor/monitor_manager.py
+++ b/src/hi/apps/monitor/monitor_manager.py
@@ -123,8 +123,8 @@ class AppMonitorManager( Singleton ):
                         periodic_monitor_class_list.append( attr )
                     continue                
                 
-            except Exception as e:
-                logger.exception( f'Problem loading monitor for {module_name}.', e )
+            except Exception:
+                logger.exception( f'Problem loading monitor for {module_name}.' )
             continue
 
         return periodic_monitor_class_list

--- a/src/hi/apps/notify/notification_manager.py
+++ b/src/hi/apps/notify/notification_manager.py
@@ -91,7 +91,7 @@ class NotificationManager( Singleton, SettingsMixin ):
                 continue
 
         except Exception as e:
-            logger.exception( "Problem checking notifications queue", e )
+            logger.exception( "Problem checking notifications queue" )
             result.error_messages.append(f"Queue check failed: {str(e)[:100]}")
 
         return result

--- a/src/hi/apps/notify/notification_queue.py
+++ b/src/hi/apps/notify/notification_queue.py
@@ -30,8 +30,8 @@ class NotificationQueue:
             queue = self._queues_map[notification_item.signature]
             queue.add_to_queue( notification_item )
 
-        except Exception as e:
-            logger.exception( 'Problem adding notification to notification queue.', e )
+        except Exception:
+            logger.exception( 'Problem adding notification to notification queue.' )
         finally:
             self._queues_lock.release()
         return
@@ -54,8 +54,8 @@ class NotificationQueue:
                 logger.debug( f'Notify queue "{signature}" emitted {len(notification_item_list)} items.' )
                 continue
 
-        except Exception as e:
-            logger.exception( 'Problem checking notification queues.', e )
+        except Exception:
+            logger.exception( 'Problem checking notification queues.' )
         finally:
             self._queues_lock.release()
 

--- a/src/hi/apps/notify/views.py
+++ b/src/hi/apps/notify/views.py
@@ -41,7 +41,7 @@ class EmailUnsubscribeView( View ):
 
         try:
             UnsubscribedEmail.objects.create( email = email )
-        except Exception as e:
-            logger.exception( f'Problem unsubscribing email {email}', e )
+        except Exception:
+            logger.exception( f'Problem unsubscribing email {email}' )
         
         return render( request, self.SUCCESS_PAGE_TEMPLATE_NAME, context )

--- a/src/hi/apps/security/security_manager.py
+++ b/src/hi/apps/security/security_manager.py
@@ -56,8 +56,8 @@ class SecurityManager( Singleton, SettingsMixin ):
             return
         try:
             self._initialize_security_state()
-        except Exception as e:
-            logger.exception( 'Problem trying to initialize security state', e )
+        except Exception:
+            logger.exception( 'Problem trying to initialize security state' )
             self._security_state = SecurityState.DISABLED
         self._was_initialized = True
         return

--- a/src/hi/apps/weather/interval_data_manager.py
+++ b/src/hi/apps/weather/interval_data_manager.py
@@ -47,8 +47,8 @@ class IntervalDataManager:
             return
         try:
             self._initialize()
-        except Exception as e:
-            logger.exception( 'Problem trying to initialize time interval data', e )
+        except Exception:
+            logger.exception( 'Problem trying to initialize time interval data' )
         self._was_initialized = True
         return
    

--- a/src/hi/apps/weather/weather_manager.py
+++ b/src/hi/apps/weather/weather_manager.py
@@ -100,8 +100,8 @@ class WeatherManager( Singleton, SettingsMixin, AlertMixin ):
             return
         try:
             self._initialize()
-        except Exception as e:
-            logger.exception( 'Problem trying to initialize weather', e )
+        except Exception:
+            logger.exception( 'Problem trying to initialize weather' )
         self._was_initialized = True
         return
 

--- a/src/hi/integrations/integration_manager.py
+++ b/src/hi/integrations/integration_manager.py
@@ -389,8 +389,8 @@ class IntegrationManager( Singleton ):
                         integration_id_to_gateway[integration_id] = integration_gateway
                     continue                
                 
-            except Exception as e:
-                logger.exception( f'Problem getting integration gateway for {module_name}.', e )
+            except Exception:
+                logger.exception( f'Problem getting integration gateway for {module_name}.' )
             continue
 
         return integration_id_to_gateway

--- a/src/hi/testing/devtools/views.py
+++ b/src/hi/testing/devtools/views.py
@@ -24,8 +24,8 @@ class DevtoolsHomeView( View ):
                 if module:
                     app_url_list.append( ( short_name, f'{short_name}/' ) )
                 
-            except Exception as e:
-                logger.exception( f'Problem loading DevTools for {short_name}.', e )
+            except Exception:
+                logger.exception( f'Problem loading DevTools for {short_name}.' )
 
             continue
         context = {

--- a/src/hi/testing/ui/views.py
+++ b/src/hi/testing/ui/views.py
@@ -24,8 +24,8 @@ class TestingHomeView( View ):
                 if module:
                     app_url_list.append( ( short_name, f'{short_name}/' ) )
                 
-            except Exception as e:
-                logger.exception( f'Problem loading UI tests for {short_name}.', e )
+            except Exception:
+                logger.exception( f'Problem loading UI tests for {short_name}.' )
 
             continue
         context = {


### PR DESCRIPTION
## Pull Request: Fix SecurityManager SynchronousOnlyOperation on async startup

### Issue Link

Closes #404

---

## Category

- [ ] **Feature** (New functionality)
- [x] **Bugfix** (Fixes an issue)
- [ ] **Docs** (Documentation updates)
- [ ] **Ops** (Infrastructure, CI/CD, build tools)

- [ ] **Tests** (Adding/improving tests)
- [ ] **Refactor** (Code/Style improvements without changing functionality)
- [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

- **Root cause:** `SecurityManager`/`SettingsManager` are process-wide singletons whose `ensure_initialized()` runs its ORM query exactly once. `EventManager._do_new_event_action` and `AlertManager.upsert_alarm_async` run on the asyncio event loop but obtained `SecurityManager` via the *synchronous* mixin accessor. When that async path was the first to initialize the singleton, the sync ORM query raised `SynchronousOnlyOperation`. The exception is swallowed by `ensure_initialized` (logging and forcing security state to DISABLED), so it presented only as a noisy startup traceback — surfacing when the Home Assistant connector feeds events before any synchronous request initializes the singletons.
- **Fix (event_manager):** use `await self.security_manager_async()` on the async path.
- **Fix (alert_manager):** resolve security state via the async accessor in `upsert_alarm_async` and pass it into `_upsert_alarm_impl`; the synchronous peer `upsert_alarm` is unchanged. This also closes the latent `weather_manager` alarm path.
- **Fix (event_manager control path):** `select_related('controller')` when materializing control actions, so `control_action.controller` no longer triggers a lazy synchronous ORM query on the loop (same class of bug in the same hot path).
- **Logging hygiene:** the original error was masked by `logger.exception(msg, e)`, which passes the exception as a `%`-format arg and raises `TypeError` during formatting. Corrected at all 16 sites repo-wide.
- **Tests:** added accessor-contract regression tests for both async sites and a controller-eager-load test (each verified to fail on the pre-fix code); updated one existing test coupled to the old sync accessor.
- **Unrelated test hygiene:** the PDF-thumbnail integration test now emits a diagnostic message explaining a missing `poppler` dependency instead of a bare assertion failure.

---

## How to Test

1. `make test` — full suite passes (3619 tests).
2. `make lint` — clean (no output).
3. Repro path: clean install, add the Home Assistant connector, restart the container; startup completes with no `SynchronousOnlyOperation` in the logs.

---

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Unit tests added or updated if necessary.
- [x] All tests pass (`./manage.py test`).
- [ ] Docs updated if applicable.
- [x] No breaking changes introduced.

---

### **Ready for Review?**
- [x] This PR is ready for review and merge.
- [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra
