### PR TITLE
Feature/397 Store Secret Attributes As Encrypted

### DIFF
--- a/src/hi/apps/attribute/cripto.py
+++ b/src/hi/apps/attribute/cripto.py
@@ -1,0 +1,37 @@
+import logging
+
+from django.conf import settings
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger(__name__)
+
+
+def get_cipher():
+    """Retrieves the master key from settings and initializes Fernet."""
+    key = getattr(settings, 'MASTER_ENCRYPTION_KEY', None)
+    if not key:
+        logger.critical("Security misconfiguration: MASTER_ENCRYPTION_KEY is not defined in settings.")
+        raise ValueError("The MASTER_ENCRYPTION_KEY setting is not defined.")
+    return Fernet(key)
+
+
+def encrypt_value(plain_text: str) -> str:
+    """Encrypts plain text and returns a string representation."""
+    if not plain_text:
+        return plain_text
+        
+    cipher = get_cipher()
+    return cipher.encrypt(plain_text.encode('utf-8')).decode('utf-8')
+
+
+def decrypt_value(encrypted_text: str) -> str:
+    """Decrypts the encrypted string and returns the original plain text."""
+    if not encrypted_text:
+        return encrypted_text
+        
+    cipher = get_cipher()
+    try:
+        return cipher.decrypt(encrypted_text.encode('utf-8')).decode('utf-8')
+    except Exception as e:
+        logger.warning("Unable to decrypt value.")
+        raise ValueError("Unable to decrypt value.") from e

--- a/src/hi/apps/attribute/crypto.py
+++ b/src/hi/apps/attribute/crypto.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,6 @@ def decrypt_value(encrypted_text: str) -> str:
     cipher = get_cipher()
     try:
         return cipher.decrypt(encrypted_text.encode('utf-8')).decode('utf-8')
-    except Exception as e:
-        logger.warning("Unable to decrypt value.")
-        raise ValueError("Unable to decrypt value.") from e
+    except InvalidToken:
+        logger.warning("Failed to decrypt value. Assuming legacy plain text.")
+        return encrypted_text

--- a/src/hi/apps/attribute/crypto.py
+++ b/src/hi/apps/attribute/crypto.py
@@ -6,13 +6,9 @@ from cryptography.fernet import Fernet, InvalidToken
 logger = logging.getLogger(__name__)
 
 
-def get_cipher():
+def get_cipher() -> Fernet:
     """Retrieves the master key from settings and initializes Fernet."""
-    key = getattr(settings, 'MASTER_ENCRYPTION_KEY', None)
-    if not key:
-        logger.critical("Security misconfiguration: MASTER_ENCRYPTION_KEY is not defined in settings.")
-        raise ValueError("The MASTER_ENCRYPTION_KEY setting is not defined.")
-    return Fernet(key)
+    return Fernet(settings.ENCRYPTION_KEY)
 
 
 def encrypt_value(plain_text: str) -> str:

--- a/src/hi/apps/attribute/edit_form_handler.py
+++ b/src/hi/apps/attribute/edit_form_handler.py
@@ -15,6 +15,7 @@ from .edit_context import AttributeItemEditContext
 from .enums import AttributeValueType
 from .models import AttributeModel
 from .transient_models import AttributeEditFormData, AttributeMultiEditFormData
+from .cripto import encrypt_value, decrypt_value
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,11 @@ class AttributeEditFormHandler:
         with transaction.atomic():
             if edit_form_data.owner_form:
                 edit_form_data.owner_form.save()
+
+            self.encrypt_secret_attributes(
+                formset=edit_form_data.regular_attributes_formset
+            )
+
             edit_form_data.regular_attributes_formset.save()
             
             self.process_file_title_updates(
@@ -93,6 +99,16 @@ class AttributeEditFormHandler:
             )
         return
     
+    def encrypt_secret_attributes(self, formset):
+        for form in formset.forms:
+            if not form.instance.value_type.is_secret:
+                continue
+
+            encripted_value = encrypt_value(form.instance.value)
+            print(f"Encrypting value for attribute {form.instance.id}: {form.instance.value} -> {encripted_value}")
+            decrypted_value = decrypt_value(encripted_value)  # For demonstration, decrypting immediately
+            print(f"Decrypted value for attribute {form.instance.id}: {decrypted_value}")
+
     def process_file_deletions( self,
                                 attr_item_context  : AttributeItemEditContext,
                                 request       : HttpRequest           ) -> None:

--- a/src/hi/apps/attribute/edit_form_handler.py
+++ b/src/hi/apps/attribute/edit_form_handler.py
@@ -15,7 +15,6 @@ from .edit_context import AttributeItemEditContext
 from .enums import AttributeValueType
 from .models import AttributeModel
 from .transient_models import AttributeEditFormData, AttributeMultiEditFormData
-from .cripto import encrypt_value, decrypt_value
 
 logger = logging.getLogger(__name__)
 
@@ -74,17 +73,12 @@ class AttributeEditFormHandler:
                     attr_item_context   : AttributeItemEditContext,
                     edit_form_data : AttributeEditFormData,
                     request        : HttpRequest ) -> None:
-
+        
         with transaction.atomic():
             if edit_form_data.owner_form:
                 edit_form_data.owner_form.save()
-
-            self.encrypt_secret_attributes(
-                formset=edit_form_data.regular_attributes_formset
-            )
-
             edit_form_data.regular_attributes_formset.save()
-            
+
             self.process_file_title_updates(
                 attr_item_context = attr_item_context,
                 request = request,
@@ -98,16 +92,6 @@ class AttributeEditFormHandler:
                 request = request,
             )
         return
-    
-    def encrypt_secret_attributes(self, formset):
-        for form in formset.forms:
-            if not form.instance.value_type.is_secret:
-                continue
-
-            encripted_value = encrypt_value(form.instance.value)
-            print(f"Encrypting value for attribute {form.instance.id}: {form.instance.value} -> {encripted_value}")
-            decrypted_value = decrypt_value(encripted_value)  # For demonstration, decrypting immediately
-            print(f"Decrypted value for attribute {form.instance.id}: {decrypted_value}")
 
     def process_file_deletions( self,
                                 attr_item_context  : AttributeItemEditContext,

--- a/src/hi/apps/attribute/forms.py
+++ b/src/hi/apps/attribute/forms.py
@@ -7,6 +7,7 @@ from hi.apps.common.utils import is_blank, str_to_bool
 
 from .enums import AttributeType, AttributeValueType
 from .thumbnail import AttributeThumbnail
+from .crypto import encrypt_value, decrypt_value
 
 
 class RegularAttributeBaseFormSet(forms.BaseInlineFormSet):
@@ -103,6 +104,10 @@ class AttributeForm( forms.ModelForm ):
         # For boolean attributes, keep string field but set initial as string consistently  
         if instance and instance.value_type.is_boolean:
             self.initial['value'] = str(str_to_bool(instance.value))
+
+        if instance and instance.value_type.is_secret:
+            if instance.value:
+                self.initial['value'] = decrypt_value(instance.value)
             
         for field in self.fields.values():
             if self._show_as_editable or ( instance and instance.is_editable ):
@@ -197,6 +202,7 @@ class AttributeForm( forms.ModelForm ):
 
             if self.cleaned_data.get('secret'):
                 instance.value_type_str = str( AttributeValueType.SECRET )
+                instance.value = encrypt_value(instance.value)
             else:
                 instance.value_type_str = str(AttributeValueType.TEXT)
 

--- a/src/hi/apps/attribute/tests/test_crypto.py
+++ b/src/hi/apps/attribute/tests/test_crypto.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for hi.apps.attribute.crypto
+
+Covers get_cipher(), encrypt_value() and decrypt_value() including edge cases,
+error handling, and missing-key misconfiguration.
+"""
+import logging
+
+from cryptography.fernet import Fernet
+from hi.testing.base_test_case import BaseTestCase
+from hi.apps.attribute.crypto import encrypt_value, decrypt_value, get_cipher
+
+logging.disable(logging.CRITICAL)
+
+TEST_ENCRYPTION_KEY = Fernet.generate_key().decode('utf-8')
+
+
+class TestGetCipher(BaseTestCase):
+    """Tests for get_cipher() – settings wiring and error handling."""
+
+    def test_returns_fernet_instance_when_key_is_configured(self):
+        """get_cipher() should return a Fernet object when MASTER_ENCRYPTION_KEY is set."""
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            cipher = get_cipher()
+        self.assertIsInstance(cipher, Fernet)
+
+    def test_raises_value_error_when_key_is_empty(self):
+        """get_cipher() must raise ValueError when MASTER_ENCRYPTION_KEY is absent or empty."""
+        invalid_keys = [None, '']
+
+        for key in invalid_keys:
+            with self.subTest(key=key):
+                with self.settings(MASTER_ENCRYPTION_KEY=key):
+                    with self.assertRaises(ValueError) as ctx:
+                        get_cipher()
+                    
+                    self.assertIn('MASTER_ENCRYPTION_KEY', str(ctx.exception))
+
+    def test_raises_error_when_key_is_invalid(self):
+        """get_cipher() must raise ValueError or TypeError for invalid keys."""
+        invalid_format_keys = [
+            'too_short_key',
+            'this_key_is_way_too_long_to_be_a_valid_fernet_key',
+            'not_base64_!@#$%^&*()',
+            123456789,
+            ['a_list_instead_of_string'],
+        ]
+
+        for invalid_key in invalid_format_keys:
+            with self.subTest(invalid_key=invalid_key):
+                with self.settings(MASTER_ENCRYPTION_KEY=invalid_key):
+                    with self.assertRaises((ValueError, TypeError)):
+                        get_cipher()
+
+
+class TestEncryptValue(BaseTestCase):
+    """Tests for encrypt_value()."""
+
+    def test_encrypt_returns_non_empty_string(self):
+        """Encrypting a plain text value should produce a non-empty token string."""
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            result = encrypt_value('my_secret')
+        self.assertIsInstance(result, str)
+        self.assertTrue(result)
+
+    def test_encrypted_value_differs_from_plain_text(self):
+        """The ciphertext must not equal the original plain text."""
+        plain = 'my_secret'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            result = encrypt_value(plain)
+        self.assertNotEqual(result, plain)
+
+    def test_two_encryptions_of_same_value_differ(self):
+        """Fernet uses a random Initialization Vector (IV), so two encryptions of the same plain text differ."""
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            first = encrypt_value('my_secret')
+            second = encrypt_value('my_secret')
+        self.assertNotEqual(first, second)
+
+    def test_returns_falsy_values_unchanged(self):
+        """encrypt_value() should return falsy values ('', None) unchanged."""
+        falsy_values = ['', None]
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            for value in falsy_values:
+                with self.subTest(value=value):
+                    result = encrypt_value(value)
+                    self.assertEqual(result, value)
+
+    def test_encrypts_unicode_text(self):
+        """encrypt_value() should handle UTF-8 content such as accented characters."""
+        unicode_text = 'café résumé naïve'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            result = encrypt_value(unicode_text)
+        self.assertIsInstance(result, str)
+        self.assertNotEqual(result, unicode_text)
+
+    def test_raises_without_key_configured(self):
+        """encrypt_value() must propagate the ValueError from get_cipher()."""
+        with self.settings(MASTER_ENCRYPTION_KEY=None):
+            with self.assertRaises(ValueError):
+                encrypt_value('my_secret')
+
+
+class TestDecryptValue(BaseTestCase):
+    """Tests for decrypt_value()."""
+
+    def test_decrypt_recovers_original_plain_text(self):
+        """Round-trip: decrypt(encrypt(x)) == x."""
+        plain = 'my_secret'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            recovered = decrypt_value( encrypt_value(plain) )
+        self.assertEqual(recovered, plain)
+
+    def test_decrypt_recovers_unicode_text(self):
+        """Round-trip with non-ASCII characters should preserve all code-points."""
+        plain = 'pässwörd_ñoño'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            recovered = decrypt_value( encrypt_value(plain) )
+        self.assertEqual(recovered, plain)
+
+    def test_returns_falsy_values_unchanged(self):
+        """decrypt_value() must return falsy values ('', None) without attempting decryption."""
+        falsy_values = ['', None]
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            for value in falsy_values:
+                with self.subTest(value=value):
+                    result = decrypt_value(value)
+                    self.assertEqual(result, value)
+
+    def test_raises_without_key_configured(self):
+        """decrypt_value() must propagate the ValueError from get_cipher()."""
+        with self.settings(MASTER_ENCRYPTION_KEY=None):
+            with self.assertRaises(ValueError):
+                decrypt_value('my_secret')
+
+
+class TestEncryptDecryptRoundTrip(BaseTestCase):
+    """Integration-style round-trip tests ensuring symmetry."""
+
+    def test_round_trip_preserves_whitespace(self):
+        """Leading/trailing whitespace in the plain text must be preserved."""
+        plain = '   padded value   '
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
+
+    def test_round_trip_preserves_newlines(self):
+        """Newline characters inside the value must survive the round-trip."""
+        plain = 'line1\nline2\nline3'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
+
+    def test_round_trip_preserves_special_characters(self):
+        """Special characters (symbols, punctuation) must be preserved exactly."""
+        plain = '!@#$%^&*()_+-=[]{}|;\':",.<>?/`~\\'
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
+
+    def test_round_trip_with_long_value(self):
+        """Encryption/decryption must work for values well beyond a single block."""
+        plain = 'A' * 10_000
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            self.assertEqual(decrypt_value(encrypt_value(plain)), plain)

--- a/src/hi/apps/attribute/tests/test_crypto.py
+++ b/src/hi/apps/attribute/tests/test_crypto.py
@@ -19,38 +19,10 @@ class TestGetCipher(BaseTestCase):
     """Tests for get_cipher() – settings wiring and error handling."""
 
     def test_returns_fernet_instance_when_key_is_configured(self):
-        """get_cipher() should return a Fernet object when MASTER_ENCRYPTION_KEY is set."""
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        """get_cipher() should return a Fernet object when ENCRYPTION_KEY is set."""
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             cipher = get_cipher()
         self.assertIsInstance(cipher, Fernet)
-
-    def test_raises_value_error_when_key_is_empty(self):
-        """get_cipher() must raise ValueError when MASTER_ENCRYPTION_KEY is absent or empty."""
-        invalid_keys = [None, '']
-
-        for key in invalid_keys:
-            with self.subTest(key=key):
-                with self.settings(MASTER_ENCRYPTION_KEY=key):
-                    with self.assertRaises(ValueError) as ctx:
-                        get_cipher()
-                    
-                    self.assertIn('MASTER_ENCRYPTION_KEY', str(ctx.exception))
-
-    def test_raises_error_when_key_is_invalid(self):
-        """get_cipher() must raise ValueError or TypeError for invalid keys."""
-        invalid_format_keys = [
-            'too_short_key',
-            'this_key_is_way_too_long_to_be_a_valid_fernet_key',
-            'not_base64_!@#$%^&*()',
-            123456789,
-            ['a_list_instead_of_string'],
-        ]
-
-        for invalid_key in invalid_format_keys:
-            with self.subTest(invalid_key=invalid_key):
-                with self.settings(MASTER_ENCRYPTION_KEY=invalid_key):
-                    with self.assertRaises((ValueError, TypeError)):
-                        get_cipher()
 
 
 class TestEncryptValue(BaseTestCase):
@@ -58,7 +30,7 @@ class TestEncryptValue(BaseTestCase):
 
     def test_encrypt_returns_non_empty_string(self):
         """Encrypting a plain text value should produce a non-empty token string."""
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             result = encrypt_value('my_secret')
         self.assertIsInstance(result, str)
         self.assertTrue(result)
@@ -66,13 +38,13 @@ class TestEncryptValue(BaseTestCase):
     def test_encrypted_value_differs_from_plain_text(self):
         """The ciphertext must not equal the original plain text."""
         plain = 'my_secret'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             result = encrypt_value(plain)
         self.assertNotEqual(result, plain)
 
     def test_two_encryptions_of_same_value_differ(self):
         """Fernet uses a random Initialization Vector (IV), so two encryptions of the same plain text differ."""
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             first = encrypt_value('my_secret')
             second = encrypt_value('my_secret')
         self.assertNotEqual(first, second)
@@ -81,7 +53,7 @@ class TestEncryptValue(BaseTestCase):
         """encrypt_value() should return falsy values ('', None) unchanged."""
         falsy_values = ['', None]
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             for value in falsy_values:
                 with self.subTest(value=value):
                     result = encrypt_value(value)
@@ -90,16 +62,10 @@ class TestEncryptValue(BaseTestCase):
     def test_encrypts_unicode_text(self):
         """encrypt_value() should handle UTF-8 content such as accented characters."""
         unicode_text = 'café résumé naïve'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             result = encrypt_value(unicode_text)
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, unicode_text)
-
-    def test_raises_without_key_configured(self):
-        """encrypt_value() must propagate the ValueError from get_cipher()."""
-        with self.settings(MASTER_ENCRYPTION_KEY=None):
-            with self.assertRaises(ValueError):
-                encrypt_value('my_secret')
 
 
 class TestDecryptValue(BaseTestCase):
@@ -108,14 +74,14 @@ class TestDecryptValue(BaseTestCase):
     def test_decrypt_recovers_original_plain_text(self):
         """Round-trip: decrypt(encrypt(x)) == x."""
         plain = 'my_secret'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             recovered = decrypt_value( encrypt_value(plain) )
         self.assertEqual(recovered, plain)
 
     def test_decrypt_recovers_unicode_text(self):
         """Round-trip with non-ASCII characters should preserve all code-points."""
         plain = 'pässwörd_ñoño'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             recovered = decrypt_value( encrypt_value(plain) )
         self.assertEqual(recovered, plain)
 
@@ -123,17 +89,11 @@ class TestDecryptValue(BaseTestCase):
         """decrypt_value() must return falsy values ('', None) without attempting decryption."""
         falsy_values = ['', None]
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             for value in falsy_values:
                 with self.subTest(value=value):
                     result = decrypt_value(value)
                     self.assertEqual(result, value)
-
-    def test_raises_without_key_configured(self):
-        """decrypt_value() must propagate the ValueError from get_cipher()."""
-        with self.settings(MASTER_ENCRYPTION_KEY=None):
-            with self.assertRaises(ValueError):
-                decrypt_value('my_secret')
 
 
 class TestEncryptDecryptRoundTrip(BaseTestCase):
@@ -142,23 +102,23 @@ class TestEncryptDecryptRoundTrip(BaseTestCase):
     def test_round_trip_preserves_whitespace(self):
         """Leading/trailing whitespace in the plain text must be preserved."""
         plain = '   padded value   '
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
 
     def test_round_trip_preserves_newlines(self):
         """Newline characters inside the value must survive the round-trip."""
         plain = 'line1\nline2\nline3'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
 
     def test_round_trip_preserves_special_characters(self):
         """Special characters (symbols, punctuation) must be preserved exactly."""
         plain = '!@#$%^&*()_+-=[]{}|;\':",.<>?/`~\\'
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             self.assertEqual(decrypt_value(encrypt_value(plain)), plain)
 
     def test_round_trip_with_long_value(self):
         """Encryption/decryption must work for values well beyond a single block."""
         plain = 'A' * 10_000
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             self.assertEqual(decrypt_value(encrypt_value(plain)), plain)

--- a/src/hi/apps/entity/tests/test_secret_attribute_encryption.py
+++ b/src/hi/apps/entity/tests/test_secret_attribute_encryption.py
@@ -1,0 +1,205 @@
+"""
+SECRET attribute encryption integration tests.
+
+Tests SECRET attribute encryption during form save, decryption during form
+load, and end-to-end round-trip.
+"""
+import logging
+
+from cryptography.fernet import Fernet
+
+from django.http import QueryDict
+
+from hi.apps.attribute.crypto import encrypt_value, decrypt_value
+from hi.apps.attribute.enums import AttributeType, AttributeValueType
+
+from hi.apps.attribute.edit_form_handler import AttributeEditFormHandler
+
+from hi.apps.entity.forms import EntityAttributeForm
+from hi.apps.entity.models import Entity, EntityAttribute
+from hi.apps.entity.tests.synthetic_data import EntityAttributeSyntheticData
+from hi.apps.entity.entity_attribute_edit_context import EntityAttributeItemEditContext
+
+from hi.testing.base_test_case import BaseTestCase, MockRequest, MockSession
+
+logging.disable(logging.CRITICAL)
+
+TEST_ENCRYPTION_KEY = Fernet.generate_key().decode('utf-8')
+
+
+class TestSecretAttributeEncryption(BaseTestCase):
+    """Tests for SECRET attributes encryption and decryption."""
+
+    def test_save_new_secret_attribute_stores_ciphertext_not_plaintext(self):
+        """Test that new SECRET attributes are encrypted before saving."""
+
+        plain = 'my_api_key_12345'
+        entity = self._create_entity()
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            form = self._build_bound_form(entity, value=plain, secret=True)
+            self.assertTrue(form.is_valid(), form.errors)
+            saved_attr = form.save()
+
+        saved_attr.refresh_from_db()
+
+        self.assertEqual(saved_attr.value_type, AttributeValueType.SECRET)
+        self.assertNotEqual(
+            saved_attr.value, plain,
+            'The plain-text value must not be stored directly in the database.',
+        )
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            decrypted = decrypt_value(saved_attr.value)
+            self.assertEqual(decrypted, plain)
+
+    def test_save_new_non_secret_attribute_stores_plaintext(self):
+        """Test that non-secret attributes are stored as plain text."""
+
+        plain = 'ordinary_value'
+        entity = self._create_entity()
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            form = self._build_bound_form(entity, value=plain, secret=False)
+            self.assertTrue(form.is_valid(), form.errors)
+            saved_attr = form.save()
+
+        saved_attr.refresh_from_db()
+
+        self.assertEqual(saved_attr.value_type, AttributeValueType.TEXT)
+        self.assertEqual(saved_attr.value, plain)
+
+    def test_form_initial_value_is_decrypted_plain_text(self):
+        """Test that SECRET attributes are decrypted when the form is loaded."""
+
+        plain = 'secret_token_xyz'
+        attr = self._create_encrypted_attribute(plain)
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            form = EntityAttributeForm(instance=attr)
+
+        self.assertEqual(
+            form.initial.get('value'), plain,
+            'form.initial["value"] must be the decrypted plain text, not the ciphertext.',
+        )
+
+    def test_handler_save_then_load_round_trip(self):
+        """Test round-trip encryption."""
+
+        plain = 'my_secret'
+        entity = self._create_entity()
+        context = self._make_context(entity)
+        handler = AttributeEditFormHandler()
+        post_data = self._create_secret_post_data(entity, context, plain)
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            form_data = handler.create_edit_form_data(
+                attr_item_context=context,
+                form_data=post_data,
+            )
+            self.assertTrue(
+                handler.validate_forms(edit_form_data=form_data),
+                f'Form validation failed: {form_data.regular_attributes_formset.errors}',
+            )
+            handler.save_forms(
+                attr_item_context=context,
+                edit_form_data=form_data,
+                request=self._make_request(post_data),
+            )
+
+            saved_attr = EntityAttribute.objects.get(
+                entity=entity,
+                name='my_secret_attr',
+            )
+            self.assertNotEqual(
+                saved_attr.value, plain,
+                'Ciphertext must differ from the plain-text submission.',
+            )
+            self.assertEqual(saved_attr.value_type, AttributeValueType.SECRET)
+
+            load_form_data = handler.create_edit_form_data(
+                attr_item_context=context,
+            )
+            
+            formset = load_form_data.regular_attributes_formset
+            secret_form = next(
+                (f for f in formset.forms if f.instance.pk == saved_attr.pk),
+                None,
+            )
+            
+        self.assertIsNotNone(
+            secret_form,
+            'Expected to find the saved SECRET attribute in the formset.',
+        )
+        self.assertEqual(
+            secret_form.initial.get('value'), plain,
+            'The form initial value must be the decrypted plain text, ready for the frontend.',
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_entity(self, name: str = 'Test Entity') -> Entity:
+        return EntityAttributeSyntheticData.create_test_entity(name=name)
+
+    def _build_bound_form( self, 
+                           entity: Entity, 
+                           value: str, 
+                           secret: bool = True ) -> EntityAttributeForm:
+        
+        new_instance = EntityAttribute(entity=entity)
+        data = {
+            'name': 'api_key',
+            'value': value,
+            'secret': str(secret),
+            'order_id': '0',
+        }
+        return EntityAttributeForm(data, instance=new_instance)
+
+    def _create_encrypted_attribute( self, plain: str, entity: Entity = None ) -> EntityAttribute:
+        if entity is None:
+            entity = self._create_entity()
+
+        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+            ciphertext = encrypt_value(plain)
+
+        return EntityAttribute.objects.create(
+            entity=entity,
+            name='stored_secret',
+            value=ciphertext,
+            attribute_type_str=str(AttributeType.CUSTOM),
+            value_type_str=str(AttributeValueType.SECRET),
+        )
+
+    def _make_request(self, post_data: dict) -> MockRequest:
+        qd = QueryDict(mutable=True)
+        for key, value in post_data.items():
+            qd[key] = value
+        request = MockRequest()
+        request.POST = qd
+        request.session = MockSession()
+        return request
+
+    def _make_context(self, entity: Entity) -> EntityAttributeItemEditContext:
+        return EntityAttributeItemEditContext(entity=entity)
+
+    def _create_secret_post_data( self, 
+                                  entity: Entity, 
+                                  context: EntityAttributeItemEditContext, 
+                                  plain_value: str ) -> dict:
+
+        prefix = context.formset_prefix
+        return {
+            'name': entity.name,
+            'entity_type_str': entity.entity_type_str,
+            f'{prefix}-TOTAL_FORMS': '1',
+            f'{prefix}-INITIAL_FORMS': '0',
+            f'{prefix}-MIN_NUM_FORMS': '0',
+            f'{prefix}-MAX_NUM_FORMS': '100',
+            f'{prefix}-0-id': '',
+            f'{prefix}-0-name': 'my_secret_attr',
+            f'{prefix}-0-value': plain_value,
+            f'{prefix}-0-secret': 'on',
+            f'{prefix}-0-order_id': '0',
+        }

--- a/src/hi/apps/entity/tests/test_secret_attribute_encryption.py
+++ b/src/hi/apps/entity/tests/test_secret_attribute_encryption.py
@@ -36,7 +36,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
         plain = 'my_api_key_12345'
         entity = self._create_entity()
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             form = self._build_bound_form(entity, value=plain, secret=True)
             self.assertTrue(form.is_valid(), form.errors)
             saved_attr = form.save()
@@ -49,7 +49,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
             'The plain-text value must not be stored directly in the database.',
         )
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             decrypted = decrypt_value(saved_attr.value)
             self.assertEqual(decrypted, plain)
 
@@ -59,7 +59,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
         plain = 'ordinary_value'
         entity = self._create_entity()
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             form = self._build_bound_form(entity, value=plain, secret=False)
             self.assertTrue(form.is_valid(), form.errors)
             saved_attr = form.save()
@@ -75,7 +75,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
         plain = 'secret_token_xyz'
         attr = self._create_encrypted_attribute(plain)
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             form = EntityAttributeForm(instance=attr)
 
         self.assertEqual(
@@ -92,7 +92,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
         handler = AttributeEditFormHandler()
         post_data = self._create_secret_post_data(entity, context, plain)
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             form_data = handler.create_edit_form_data(
                 attr_item_context=context,
                 form_data=post_data,
@@ -161,7 +161,7 @@ class TestSecretAttributeEncryption(BaseTestCase):
         if entity is None:
             entity = self._create_entity()
 
-        with self.settings(MASTER_ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
+        with self.settings(ENCRYPTION_KEY=TEST_ENCRYPTION_KEY):
             ciphertext = encrypt_value(plain)
 
         return EntityAttribute.objects.create(

--- a/src/hi/environment/server.py
+++ b/src/hi/environment/server.py
@@ -36,6 +36,7 @@ class EnvironmentSettings:
     EXTRA_CSP_URLS             : Tuple[ str ]  = field( default_factory = tuple )
     DATABASES_NAME_PATH        : str           = None
     MEDIA_ROOT                 : str           = None
+    ENCRYPTION_KEY      : str           = '-IvqgosaU7R6rychu4fdTd93OlWuAtD8gpJINa-qMog='
     REDIS_HOST                 : str           = 'localhost'
     REDIS_PORT                 : int           = 6379
     SUPPRESS_AUTHENTICATION    : bool          = True
@@ -116,6 +117,10 @@ class EnvironmentSettings:
         env_settings.MEDIA_ROOT = cls.get_env_variable(
             'HI_MEDIA_PATH',
             env_settings.MEDIA_ROOT,
+        )
+        env_settings.ENCRYPTION_KEY = cls.get_env_variable(
+            'HI_ENCRYPTION_KEY',
+            env_settings.ENCRYPTION_KEY,
         )
 
         ###########

--- a/src/hi/requirements/development.txt
+++ b/src/hi/requirements/development.txt
@@ -8,3 +8,4 @@ jedi==0.19.2
 pipdeptree==2.28.0
 rope==1.14.0
 yapf==0.43.0
+cryptography==42.0.5

--- a/src/hi/settings/base.py
+++ b/src/hi/settings/base.py
@@ -186,6 +186,8 @@ DATABASES = {
     }
 }
 
+ENCRYPTION_KEY = ENV.ENCRYPTION_KEY
+
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators

--- a/src/hi/settings/base.py
+++ b/src/hi/settings/base.py
@@ -403,6 +403,7 @@ EMAIL_USE_SSL = ENV.EMAIL_USE_SSL
 #
 BASE_URL_FOR_EMAIL_LINKS = f'http://{SITE_DOMAIN}'
 
+MASTER_ENCRYPTION_KEY = "-IvqgosaU7R6rychu4fdTd93OlWuAtD8gpJINa-qMog="
 
 # ====================
 # Development-related Settings

--- a/src/hi/settings/base.py
+++ b/src/hi/settings/base.py
@@ -403,7 +403,6 @@ EMAIL_USE_SSL = ENV.EMAIL_USE_SSL
 #
 BASE_URL_FOR_EMAIL_LINKS = f'http://{SITE_DOMAIN}'
 
-MASTER_ENCRYPTION_KEY = "-IvqgosaU7R6rychu4fdTd93OlWuAtD8gpJINa-qMog="
 
 # ====================
 # Development-related Settings


### PR DESCRIPTION
## Pull Request: Store Secret Attributes As Encrypted

### Issue Link

Closes #397 

---

## Category

* [x] **Feature** (New functionality)
* [ ] **Bugfix** (Fixes an issue)
* [ ] **Docs** (Documentation updates)
* [ ] **Ops** (Infrastructure, CI/CD, build tools)
* [x] **Tests** (Adding/improving tests)
* [ ] **Refactor** (Code/Style improvements without changing functionality)
* [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

* Created `crypto.py` using`cryptography.fernet` to handle symmetric encryption and decryption using a `ENCRYPTION_KEY` defined in the Django settings.

* Updated `AttributeForm.save()` to encrypt SECRET attribute values before the database commit, guaranteeing SECRET attribute values are protected at rest.

* Overrode `AttributeForm.__init__` to decrypt SECRET attributes upon loading, ensuring the frontend receives plain text to properly render the password-toggle UI.

* Added unit tests for `crypto.py` and end-to-end integration tests (`TestSecretAttributeEncryption`) verifying the round-trip encryption lifecycle.

---

## How to Test

1. Generate a valid Fernet key in your Python shell (`from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())`) and set it as `ENCRYPTION_KEY` in your local `.env` file.
2. Create a new attribute in the UI, check the "Mark as Secret" box, input a value, and save the form.
3. Verify in the database that the stored `value` is now an encrypted Fernet token rather than plain text.
4. Reload the attribute in the UI and click the toggle (eye icon) to ensure the plain text is correctly decrypted and displayed.
---

## Checklist

* [x] Code follows the project's style guidelines.
* [x] Unit tests added or updated if necessary.
* [x] All tests pass (`./manage.py test`).
* [ ] Docs updated if applicable.
* [x] No breaking changes introduced.

---

### **Ready for Review?**

* [ ] This PR is ready for review and merge.
* [x] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra