### PR TITLE
Feature/261 Add Redis Authentication Support

### DIFF
--- a/deploy/env-generate.py
+++ b/deploy/env-generate.py
@@ -143,6 +143,7 @@ class HiEnvironmentGenerator:
             ( 'HI_REDIS_HOST', '127.0.0.1' ),
             ( 'HI_REDIS_PORT', '6379' ),
             ( 'HI_REDIS_KEY_PREFIX', '' ),
+            ( 'HI_REDIS_PASSWORD', '' ),
         ] ),
         ( 'Authentication',
           'optional; "true" disables login for simple single-user setups', [
@@ -224,6 +225,7 @@ class HiEnvironmentGenerator:
             'HI_REDIS_HOST': '127.0.0.1',
             'HI_REDIS_PORT': '6379',
             'HI_REDIS_KEY_PREFIX': self._env_config.redis_key_prefix,
+            'HI_REDIS_PASSWORD': '',  # Optional; empty means no Redis auth (backward-compatible)
             'HI_EMAIL_SUBJECT_PREFIX': self._env_config.redis_subject_prefix,
             'HI_EXTRA_HOST_URLS': '',  # To be filled in manually if/when running beyond localhost
             'HI_EXTRA_CSP_URLS': '',  # To be filled in manually if/when running beyond localhost

--- a/install.sh
+++ b/install.sh
@@ -223,6 +223,7 @@ HI_MEDIA_PATH=/data/media
 HI_REDIS_HOST=127.0.0.1
 HI_REDIS_PORT=6379
 HI_REDIS_KEY_PREFIX=
+HI_REDIS_PASSWORD=
 
 # Authentication (disabled for simple setup)
 HI_SUPPRESS_AUTHENTICATION=true

--- a/local.env.example
+++ b/local.env.example
@@ -34,6 +34,8 @@ HI_MEDIA_PATH=/data/media
 HI_REDIS_HOST=127.0.0.1
 HI_REDIS_PORT=6379
 HI_REDIS_KEY_PREFIX=
+# --- Redis authentication (optional; leave empty if Redis requires no password) ---
+HI_REDIS_PASSWORD=
 
 # --- Authentication (optional; "true" disables login for simple single-user setups) ---
 HI_SUPPRESS_AUTHENTICATION=true

--- a/src/hi/apps/common/redis_client.py
+++ b/src/hi/apps/common/redis_client.py
@@ -31,22 +31,27 @@ def initialize_global_cache_client():
     if _g_global_redis_client:
         _g_global_redis_client = None  # No good way to explicitly "close" this
 
-    host, port = ( settings.REDIS_HOST, settings.REDIS_PORT )
+    host, port, password = ( settings.REDIS_HOST, settings.REDIS_PORT, settings.REDIS_PASSWORD )
     if not port:
         port = 6379
 
     logger.info( "Attempting to connect to Redis at %s:%s ..." % ( host, port ))
 
+    kwargs = {
+        "host": host,
+        "port": port,
+        "db": 0,
+        "socket_timeout": 5,
+        "socket_connect_timeout": 5,
+        "decode_responses": True,
+    }
+    if password:
+        kwargs["password"] = password
+        
     try:
-        _g_global_redis_client = redis.StrictRedis( host = host,
-                                                    port = port,
-                                                    db = 0,
-                                                    socket_timeout = 5,
-                                                    socket_connect_timeout = 5,
-                                                    decode_responses = True )
+        _g_global_redis_client = redis.StrictRedis( **kwargs )
         _g_global_redis_client.ping()
         logger.info( "Successfully connected to Redis at %s:%s" % ( host, port ))
-        
     except ( ConnectionRefusedError, redis.exceptions.ConnectionError ) as e:
         logger.error( f'Could not connect to Redis server: {e}' )
         _g_global_redis_client = None

--- a/src/hi/environment/server.py
+++ b/src/hi/environment/server.py
@@ -38,6 +38,7 @@ class EnvironmentSettings:
     MEDIA_ROOT                 : str           = None
     REDIS_HOST                 : str           = 'localhost'
     REDIS_PORT                 : int           = 6379
+    REDIS_PASSWORD             : str           = ''
     SUPPRESS_AUTHENTICATION    : bool          = True
     EMAIL_SUBJECT_PREFIX       : str           = ''
     DEFAULT_FROM_EMAIL         : str           = ''
@@ -132,6 +133,11 @@ class EnvironmentSettings:
             ))
         except ( TypeError, ValueError ):
             pass
+
+        env_settings.REDIS_PASSWORD = cls.get_env_variable(
+            'HI_REDIS_PASSWORD',
+            env_settings.REDIS_PASSWORD,
+        )
 
         ###########
         # Email-related

--- a/src/hi/settings/base.py
+++ b/src/hi/settings/base.py
@@ -356,13 +356,14 @@ CONSTANCE_CONFIG = {
 
 REDIS_HOST = ENV.REDIS_HOST
 REDIS_PORT = ENV.REDIS_PORT
+REDIS_PASSWORD = ENV.REDIS_PASSWORD
 
 CACHES = {
     'default': {
         # 'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
         'BACKEND': 'django.core.cache.backends.redis.RedisCache',
         'LOCATION': [
-            f'redis://{REDIS_HOST}:{REDIS_PORT}',
+            f'redis://{REDIS_HOST}:{REDIS_PORT}' if not REDIS_PASSWORD else f'redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}',
         ],
         "KEY_PREFIX": 'main:',
     }


### PR DESCRIPTION
## Pull Request: Add Redis Authentication Support

### Issue Link

Closes #261

---

## Category

* [x] **Feature** (New functionality)
* [ ] **Bugfix** (Fixes an issue)
* [x] **Docs** (Documentation updates)
* [x] **Ops** (Infrastructure, CI/CD, build tools)
* [ ] **Tests** (Adding/improving tests)
* [ ] **Refactor** (Code/Style improvements without changing functionality)
* [ ] **Tweak** (Minor UI or code improvements)

---

## Changes Summary

* Added `REDIS_PASSWORD` to `EnvironmentSettings` (reading from `HI_REDIS_PASSWORD`) with an empty string as the default to maintain backward compatibility.
* Updated the Redis connection URI in `settings/base.py` to conditionally inject the password if one is provided.
* Updated `StrictRedis` initialization in `apps/common/redis_client.py` to accept and pass the authentication credentials.
* Synchronized the new variable across the deployment tools by adding `HI_REDIS_PASSWORD` to `deploy/env-generate.py` , `local.env.example` , and `install.sh`.

---

## How to Test

1. **Test with Authentication:** Set up a local Redis container/instance configured to require a password. Set `HI_REDIS_PASSWORD=your_password` in your local `.env` file, start the application, and verify that the system connects to Redis without authentication errors.
2. **Test Backward Compatibility:** Remove the `HI_REDIS_PASSWORD` from your `.env` file and restart the application against a standard Redis instance with no password. Ensure the application connects successfully as it did before.
3. **Verify Install Scripts:** Inspect `local.env.example` and the generated `.env` file from `install.sh` to ensure the new variable is correctly stubbed out for new users.

---

## Checklist

* [x] Code follows the project's style guidelines.
* [ ] Unit tests added or updated if necessary.
* [x] All tests pass (`./manage.py test`).
* [x] Docs updated if applicable.
* [x] No breaking changes introduced.

---

### **Ready for Review?**

* [x] This PR is ready for review and merge.
* [ ] This PR requires more work before approval.

---

### **Reviewer(s)**

@cassandra