### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #414)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, TodoWrite
 description: Post-PR branch cleanup following our safety procedures
-argument-hint: [feature-branch-name]
+argument-hint: "[feature-branch-name]"
 ---
 
 Post-PR cleanup for merged feature branch "$0" following `docs/dev/workflow/workflow-guidelines.md`:

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, TodoWrite
 description: Create smart commits following our message standards
-argument-hint: [commit-message]
+argument-hint: "[commit-message]"
 ---
 
 Create commit with message "$0" following our standards from `docs/dev/workflow/workflow-guidelines.md`:

--- a/.claude/commands/createissue.md
+++ b/.claude/commands/createissue.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, TodoWrite
 description: Create GitHub issues using proper templates and conventions
-argument-hint: [type] [title]
+argument-hint: "[type] [title]"
 ---
 
 Create GitHub issue of type "$0" with title "$1" using proper templates and conventions:

--- a/.claude/commands/debug.md
+++ b/.claude/commands/debug.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, TodoWrite, Grep, Glob, Task
 description: Debug issues with AI-assisted analysis and troubleshooting
-argument-hint: [description]
+argument-hint: "[description]"
 ---
 
 Debug issue: "$0"

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Write, TodoWrite, Grep, Glob
 description: Design planning and HTML mockup creation for GitHub issues
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Design planning and HTML mockup creation for GitHub issue #$0:

--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Edit, Write, TodoWrite, Grep, Glob, Task
 description: Complete issue-to-PR orchestration with intelligent sub-agent coordination
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Complete issue-to-PR orchestration for GitHub issue #$0:

--- a/.claude/commands/icon.md
+++ b/.claude/commands/icon.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Write, Edit, Grep, TodoWrite
 description: Find existing icons or create new ones for the standardized icon system
-argument-hint: [concept/action]
+argument-hint: "[concept/action]"
 ---
 
 Find or create an icon for "$0":

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Edit, Write, TodoWrite, Grep, Glob, Task
 description: Implement a GitHub issue that has been picked up, stopping at PR-ready state
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Implement GitHub issue #$0 following our development standards from `docs/dev/workflow/workflow-guidelines.md`:

--- a/.claude/commands/investigate.md
+++ b/.claude/commands/investigate.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Edit, TodoWrite, Grep, Glob, Task
 description: Deep investigation and analysis of GitHub issues for implementation planning
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Deep investigation and implementation planning for GitHub issue #$0:

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Write, TodoWrite, Grep, Glob
 description: Pick up a GitHub issue — prepare branch, investigate, and produce a proposed phased work breakdown for review
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 # Pick up GitHub issue #$0

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, TodoWrite, Grep, Glob
 description: Strategic planning and work breakdown for GitHub issues
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Strategic planning and work breakdown for GitHub issue #$0:

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Write, TodoWrite
 description: Create pull request following our workflow and template requirements
-argument-hint: [title]
+argument-hint: "[title]"
 ---
 
 Create pull request with title "$0" following our workflow from `docs/dev/workflow/workflow-guidelines.md`:

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, TodoWrite, Grep, Glob, Task
 description: Plan and execute refactoring with expert analysis
-argument-hint: [target] (e.g., ClassName, module_name, or file_path)
+argument-hint: "[target] (e.g., ClassName, module_name, or file_path)"
 ---
 
 Plan refactoring for: "$0"

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, Edit, TodoWrite, Grep, Glob
 description: Execute the complete release process from staging to master
-argument-hint: [version] (e.g., v1.2.3)
+argument-hint: "[version] (e.g., v1.2.3)"
 ---
 
 Execute our complete release process following `docs/dev/workflow/release-process.md`:

--- a/.claude/commands/respond.md
+++ b/.claude/commands/respond.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash, Read, TodoWrite, Grep, Glob, Task
 description: Systematic response to GitHub pull request feedback
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 Systematic response to GitHub pull request #$0 feedback:


### PR DESCRIPTION
Closes #414.

## Summary

Purely mechanical single-character transform to 15 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (15)

- `.claude/commands/release.md`
- `.claude/commands/commit.md`
- `.claude/commands/debug.md`
- `.claude/commands/pr.md`
- `.claude/commands/refactor.md`
- `.claude/commands/design.md`
- `.claude/commands/pickup.md`
- `.claude/commands/investigate.md`
- `.claude/commands/cleanup.md`
- `.claude/commands/createissue.md`
- `.claude/commands/respond.md`
- `.claude/commands/icon.md`
- `.claude/commands/implement.md`
- `.claude/commands/plan.md`
- `.claude/commands/execute.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
